### PR TITLE
[DO NOT MERGE] eval #31961 i:1: obsolete GO:0008785  alkyl hydroperoxide reductase activity (openai/gpt-5.5, .)

### DIFF
--- a/src/ontology/comments.txt
+++ b/src/ontology/comments.txt
@@ -1383,7 +1383,7 @@ comment: This term was made obsolete because 'resistance' implies a phenotype ra
 comment: See also the molecular function term '3-isopropylmalate dehydratase activity ; GO:0003861'.
 comment: See also the molecular function term 'cytochrome o ubiquinol oxidase activity ; GO:0008827'.
 comment: See also the molecular function term 'phosphoribosylaminoimidazole carboxylase activity ; GO:0004638'.
-comment: See also the molecular function term 'alkyl hydroperoxide reductase activity ; GO:0008785'.
+comment: See also the molecular function term 'NADH-dependent peroxiredoxin activity ; GO:0102039'.
 comment: See also the molecular function term 'D-amino-acid oxidase activity ; GO:0003884'.
 comment: See also the molecular function term '3-phenylpropionate dioxygenase activity ; GO:0008695'.
 comment: This term was made obsolete because the catalytic activity resides in a single polypeptide rather than a complex, and the complex is represented by a different GO term.
@@ -3963,7 +3963,6 @@ comment: Note that this term is in the subset of terms that should not be used f
 comment: Note that as agreed during the transcription overhaul, terms specifying binding to specific transcription regulatory motifs are no longer being created. The level of specificity GO has decided to go to is the "core promoter", "core promoter proximal region" and "enhancer". To capture more detail, please consider using column 16.
 comment: See also the molecular function term 'histone acetyltransferase activity ; GO:0004402'.
 comment: Note that this term is not a child of 'co-translational protein modification process ; GO:0043686' because co-translational protein modification implies modification of a previously incorporated amino acid in a nascent chain, rather than addition of new sequence to the C-terminus.
-comment: See also the molecular function term 'alkyl hydroperoxide reductase activity ; GO:0008785'.
 comment: See also the molecular function term 'acetolactate synthase activity ; GO:0003984'.
 comment: Note that 'error-free' does not mean that literally zero errors occur during DNA synthesis, but that the error rate is low, comparable to that of DNA synthesis during replication.
 comment: This term should not be used for direct annotation. The only exception should be when experimental data (e.g., staining with trypan blue or propidium iodide or use of neuron-specific markers) show that neuron death has occurred, but fail to provide details on death modality (accidental versus programmed). When information is provided on the neuron death mechanism, annotations should be made to the appropriate descendant of 'cell death' (such as, but not limited to, GO:0097300 'programmed necrotic cell death' or GO:0006915 'apoptotic process'), and the cell type captured as an annotation extension; or the term GO:0051402 'neuron apoptotic process' may be considered, if appropriate.

--- a/src/ontology/ld.txt
+++ b/src/ontology/ld.txt
@@ -5674,7 +5674,7 @@ intersection_of: capable_of GO:0009486 ! cytochrome bo3 ubiquinol oxidase activi
 intersection_of: GO:0032991 ! protein-containing complex
 intersection_of: capable_of GO:0004638 ! phosphoribosylaminoimidazole carboxylase activity
 intersection_of: GO:0032991 ! protein-containing complex
-intersection_of: capable_of GO:0008785 ! alkyl hydroperoxide reductase activity
+intersection_of: capable_of GO:0102039 ! NADH-dependent peroxiredoxin activity
 intersection_of: GO:0032991 ! protein-containing complex
 intersection_of: capable_of GO:0009033 ! trimethylamine-N-oxide reductase activity
 intersection_of: GO:0032991 ! protein-containing complex


### PR DESCRIPTION
**⚠️ EVALUATION ONLY - DO NOT MERGE ⚠️**

## Original Issue
[#31961: obsolete GO:0008785  alkyl hydroperoxide reductase activity](https://href.li/?https://github.com/geneontology/go-ontology/issues/31961)

## Original PR (human solution)
[#32015: Obsolete GO:0008785 alkyl hydroperoxide reductase activity (#31961)](https://href.li/?https://github.com/geneontology/go-ontology/pull/32015)

## Agent Commits
- Obsolete alkyl hydroperoxide reductase activity

**Note**: This PR diff shows ONLY the agent's changes. The baseline is eval_base_branch.

## Agent Response - PR Comments
## Summary

Addressed geneontology/go-ontology#31961 by obsoleting `GO:0008785` **alkyl hydroperoxide reductase activity** and replacing it with `GO:0102039` **NADH-dependent peroxiredoxin activity**.

Changes made:

- Marked `GO:0008785` obsolete:
  - renamed to `obsolete alkyl hydroperoxide reductase activity`
  - retained the original definition with the required `OBSOLETE.` prefix
  - removed asserted parentage
  - added obsoletion reason comment
  - added `is_obsolete: true`
  - added `replaced_by: GO:0102039`
  - added the issue tracker link for #31961
- Added `alkyl hydroperoxide reductase activity` as an exact synonym on `GO:0102039`, complementing the existing no-space synonym `alkylhydroperoxide reductase activity`.
- Updated internal references away from `GO:0008785`:
  - `GO:0009321` now points its “see also” comment to `GO:0102039`.
  - Removed an unrelated stale “see also” comment from `GO:0070937`.
  - Updated the corresponding `ld.txt` capability reference from `GO:0008785` to `GO:0102039`.
  - Updated `comments.txt` accordingly.

## Rationale

The issue states that, despite the generic label, `GO:0008785` represents a substrate-specific version of the broader `GO:0102039` reaction and is more specific than the evidence supports for known gene products. `GO:0102039` already carries the appropriate EC/RHEA/MetaCyc cross-references and is therefore the correct replacement.

No new literature references were introduced. The issue already included annotation impact information and an obsoletion notice; I attempted an `amigo:` association lookup locally, but the installed OAK/linkml environment failed before querying. This did not block the ontology edit because the request specified a direct replacement and annotation impact was already supplied in the issue.

## Validation

- Pre-validation: `cd src/ontology && make travis_build` passed before edits.
- Post-edit validation: `cd src/ontology && make travis_build` passed after edits.
- Confirmed no remaining `GO:0008785` references in `go-edit.obo`, `comments.txt`, or `ld.txt` outside the obsolete term’s own stanza.

## Checklist

- [x] PLAN: Issue context reviewed; direct obsoletion with replacement was clear.
- [x] PRE-VALIDATION: Current ontology validated before edits with `make travis_build`.
- [x] RESEARCH: N/A; no new references were introduced and the issue supplied the needed replacement rationale.
- [x] TERM-SEARCH: Checked `GO:0008785`, replacement `GO:0102039`, and internal references with `obo-grep.pl`/grep.
- [x] DESIGN-PATTERNS: Reviewed applicability; no new logical definitions or term-creation pattern required. Obsoletion pattern followed.
- [x] EDITS: Used `obo-checkout.pl`/`obo-checkin.pl` for edited GO stanzas.
- [x] RELATIONSHIPS: Removed asserted parentage from obsolete term; rewired internal capability/reference metadata to `GO:0102039` where appropriate.
- [x] SPECIALIZED-EDITS: Term obsoletion procedure followed; reaction-term context checked.
- [x] METADATA: Obsolete term metadata includes obsoletion comment, tracker link, `is_obsolete`, and `replaced_by`.
- [x] AUTOMATED-VALIDATION: `make travis_build` passed after changes.
- [x] REFERENCE-VALIDATION: N/A; no new PMIDs or external references added.
- [x] CHANGES-COMMITTED: Local commit created with only the edited ontology content files staged.

---
🤖 **Generated by pi agent**
- Runtime: `pi`
- Model: `openai/gpt-5.5`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25615949678)

## Agent Response - Issue Comments
Changes committed in PR #<NN>.

Summary: `GO:0008785` has been obsoleted with `replaced_by: GO:0102039` (`NADH-dependent peroxiredoxin activity`). I also updated ontology references that pointed to the now-obsolete term.

---
🤖 **Generated by pi agent**
- Runtime: `pi`
- Model: `openai/gpt-5.5`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25615949678)

## Experiment Config
| Parameter | Value |
|-----------|-------|
| Model | `openai/gpt-5.5` |
| Agent config | `ai4curation/go-ontology-agent-config@v9:.` |
| Iteration | `1` |
| URL prefix | `https://href.li/?` |
| Base branch | `eval-base-issue-31961` |

See workflow artifacts for full agent trace.