### PR TITLE
[DO NOT MERGE] eval #32018 i:1: Obsoletion request: ergothioneine biosynthetic process terms (gpt-5.5, .)

### DIFF
--- a/src/ontology/imports/go_taxon_constraints.owl
+++ b/src/ontology/imports/go_taxon_constraints.owl
@@ -28202,25 +28202,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/GO_0052704 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0052704">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002160"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002162"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/GO_0052907 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0052907">
@@ -37884,25 +37865,6 @@
     <!-- http://purl.obolibrary.org/obo/GO_0140446 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0140446">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002160"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4751"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002162"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4751"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GO_0140479 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0140479">
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002160"/>

--- a/src/taxon_constraints/only_in_taxon.ofn
+++ b/src/taxon_constraints/only_in_taxon.ofn
@@ -642,7 +642,6 @@ Declaration(Class(<http://purl.obolibrary.org/obo/GO_0051882>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0051960>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0052324>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0052325>))
-Declaration(Class(<http://purl.obolibrary.org/obo/GO_0052704>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0052907>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0055044>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0055045>))
@@ -863,7 +862,6 @@ Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140266>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140384>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140400>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140446>))
-Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140479>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140494>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140495>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140525>))
@@ -4188,11 +4186,6 @@ SubClassOf(<http://purl.obolibrary.org/obo/GO_0052324> ObjectAllValuesFrom(<http
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0052325> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_33090>))
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0052325> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_33090>))
 
-# Class: <http://purl.obolibrary.org/obo/GO_0052704> (<http://purl.obolibrary.org/obo/GO_0052704>)
-
-SubClassOf(<http://purl.obolibrary.org/obo/GO_0052704> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_2>))
-SubClassOf(<http://purl.obolibrary.org/obo/GO_0052704> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_2>))
-
 # Class: <http://purl.obolibrary.org/obo/GO_0052907> (<http://purl.obolibrary.org/obo/GO_0052907>)
 
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0052907> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_Union_0000004>))
@@ -5292,11 +5285,6 @@ SubClassOf(Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "PMI
 
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0140446> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_4751>))
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0140446> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_4751>))
-
-# Class: <http://purl.obolibrary.org/obo/GO_0140479> (<http://purl.obolibrary.org/obo/GO_0140479>)
-
-SubClassOf(<http://purl.obolibrary.org/obo/GO_0140479> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_4751>))
-SubClassOf(<http://purl.obolibrary.org/obo/GO_0140479> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_4751>))
 
 # Class: <http://purl.obolibrary.org/obo/GO_0140494> (<http://purl.obolibrary.org/obo/GO_0140494>)
 


### PR DESCRIPTION
**⚠️ EVALUATION ONLY - DO NOT MERGE ⚠️**

## Original Issue
[#32018: Obsoletion request: ergothioneine biosynthetic process terms](https://href.li/?https://github.com/geneontology/go-ontology/issues/32018)

## Original PR (human solution)
[#32022: Obsolete GO:0061817 endoplasmic reticulum-plasma membrane tethering](https://href.li/?https://github.com/geneontology/go-ontology/pull/32022)

## Agent Commits
- Obsolete ergothioneine pathway variant terms

**Note**: This PR diff shows ONLY the agent's changes. The baseline is eval_base_branch.

## Agent Response - PR Comments
## Summary

Addressed issue #32018 by obsoleting the two ergothioneine pathway-variant BP terms:

- GO:0052704 `obsolete ergothioneine biosynthesis from histidine via gamma-glutamyl-hercynylcysteine sulfoxide`
- GO:0140479 `obsolete ergothioneine biosynthesis from histidine via hercynylcysteine sulfoxide synthase`

Both now have `replaced_by: GO:0052699`.

GO:0052699 `ergothioneine biosynthetic process` now carries:

- `xref: MetaCyc:PWY-7255 {source="skos:narrowMatch"}`
- `xref: MetaCyc:PWY-7550 {source="skos:narrowMatch"}`

I also rewired internal MF `part_of` references from the obsoleted child process terms to GO:0052699, updated older obsolete replacements/comments that pointed at GO:0052704, and removed the stale only-in-taxon generated axioms for the two newly obsolete terms.

## Rationale

The child process terms represent pathway/database-specific route variants rather than distinct GO biological process classes. The parent term already follows the biosynthetic-process design pattern with `has_primary_output CHEBI:134344 ! ergothioneine(1+)`; the local ChEBI pH 7.3 mapping confirms CHEBI:134344 as the appropriate pH 7.3 form for ergothioneine.

BioCyc XML confirmed the requested MetaCyc mappings:

- `PWY-7255`: ergothioneine biosynthesis I (bacteria)
- `PWY-7550`: ergothioneine biosynthesis II (fungi)

These are narrower than GO:0052699, so `skos:narrowMatch` on the parent is appropriate.

## Validation

- Pre-validation before edits: `make -C src/ontology travis_build` passed.
- Reference validation: `linkml-reference-validator validate text-file ... RESEARCH.md` passed for the supporting PMID excerpts.
- Post-edit validation: `make -C src/ontology travis_build` passed.

Note: `runoak -i amigo:` was unavailable because of a local Python dependency error, so direct annotation impact was checked with GOlr instead. Existing direct annotations to the obsoleted terms can migrate to GO:0052699 via `replaced_by`.

## Checklist

- [x] PLAN: issue context analyzed and intent clear.
- [x] PRE-VALIDATION: current ontology validated before edits.
- [x] RESEARCH: targeted research performed in `RESEARCH.md`; PMIDs validated.
- [x] TERM-SEARCH: GO terms and internal references checked with `obo-grep.pl`/`rg`.
- [x] DESIGN-PATTERNS: biosynthetic-process pattern documented in `DESIGN_PATTERNS.md`.
- [x] EDITS: terms edited via checkout/checkin workflow.
- [x] RELATIONSHIPS: obsolete terms have no active logical axioms; internal `part_of` references rewired to GO:0052699.
- [x] SPECIALIZED-EDITS: obsoletion, mapping, chemical-entity, design-pattern, research, and taxon-constraint guidance applied.
- [x] METADATA: issue tracker links added; no new-term creation metadata added.
- [x] AUTOMATED-VALIDATION: `make -C src/ontology travis_build` passed after changes.
- [x] REFERENCE-VALIDATION: no new PMIDs introduced; supporting research PMIDs validated.
- [x] CHANGES-COMMITTED: committed locally as `a94d943`.

---
🤖 **Generated by codex agent**
- Runtime: `codex`
- Model: `gpt-5.5`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25633568944)

## Agent Response - Issue Comments
Changes committed in PR #<NN>.

Summary: GO:0052704 and GO:0140479 have been obsoleted as pathway-variant ergothioneine biosynthetic process terms and replaced by GO:0052699. The two MetaCyc pathway variants were retained as `skos:narrowMatch` xrefs on GO:0052699. Internal GO references and stale taxon-constraint axioms were updated so the obsolete terms are not used in active axioms.

---
🤖 **Generated by codex agent**
- Runtime: `codex`
- Model: `gpt-5.5`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25633568944)

## Experiment Config
| Parameter | Value |
|-----------|-------|
| Model | `gpt-5.5` |
| Agent config | `ai4curation/go-ontology-agent-config@v9:.` |
| Iteration | `1` |
| URL prefix | `https://href.li/?` |
| Base branch | `eval-base-issue-32018` |

See workflow artifacts for full agent trace.