### PR TITLE
[DO NOT MERGE] eval #32018 i:1: Obsoletion request: ergothioneine biosynthetic process terms (openai/gpt-5.5, .)

### DIFF
--- a/src/ontology/comments.txt
+++ b/src/ontology/comments.txt
@@ -3826,7 +3826,7 @@ comment: This term was obsoleted because EC obsoleted it, and there was no other
 comment: This term was obsoleted because EC obsoleted it, and there was no other evidence that this function exists.
 comment: Note that enzymes classified as EC:1.1.5.3 have several activities. They should be annotated with the terms GO:0004368, GO:0052590 and GO:0052591.
 comment: Note that enzymes classified as EC:1.1.5.3 have several activities. They should be annotated with the terms GO:0004368, GO:0052590 and GO:0052591.
-comment: The reason for obsoletion is that this term does not provide a useful distinction from its parent, GO:0052704 (because that trimethyl-His yada is present in both pathways)
+comment: The reason for obsoletion is that this term does not provide a useful distinction from ergothioneine biosynthetic process.
 comment: Class II AP endonuclease is a nuclease, but not Class I, III and IV.
 comment: In this reaction N,N'-diacetylchitobiose is deacetylated at the non-reducing residue to produce 2-acetamido-4-O-(2-amino-2-deoxy-beta-D-glucopyranosyl)-2-deoxy-D-glucose (GlcN-GlcNAc). This is in contrast to EC:3.5.1.105 in which N,N'-diacetylchitobiose is deacetylated at the reducing residue to produce 4-O-(N-acetyl-beta-D-glucosaminyl)-D-glucosamine (GlcNAc-GlcN). For the latter reaction, see GO:0036311.
 comment: EC has determined that this reaction in fact does not exist and have withdrawn EC:1.3.3.1. Note: If fumarate is not shown to be involved, you may want to consider GO:0004152, dihydroorotate dehydrogenase activity (parent term); if the reaction involves fumarate, then use GO:0052888 dihydroorotate oxidase (fumarate) activity. Details at http://sourceforge.net/p/geneontology/ontology-requests/10770/

--- a/src/ontology/ec.obo
+++ b/src/ontology/ec.obo
@@ -41131,7 +41131,7 @@ synonym: "gamma-glutamyl hercynylcysteine sulfoxide synthase" EXACT []
 xref: EC:1.14.99.50
 xref: RHEA:42672
 is_a: GO:0016705 ! oxidoreductase activity, acting on paired donors, with incorporation or reduction of molecular oxygen
-relationship: part_of GO:0052704 ! ergothioneine biosynthesis from histidine via gamma-glutamyl-hercynylcysteine sulfoxide
+relationship: part_of GO:0052699 ! ergothioneine biosynthetic process
 property_value: term_tracker_item https://github.com/geneontology/go-ontology/issues/11163 xsd:anyURI
 created_by: jl
 creation_date: 2014-12-15T11:44:54Z
@@ -68667,7 +68667,7 @@ synonym: "hercynylcysteine sulfoxide synthase" EXACT []
 xref: EC:1.14.99.51
 xref: RHEA:42704
 is_a: GO:0016705 ! oxidoreductase activity, acting on paired donors, with incorporation or reduction of molecular oxygen
-relationship: part_of GO:0140479 ! ergothioneine biosynthesis from histidine via hercynylcysteine sulfoxide synthase
+relationship: part_of GO:0052699 ! ergothioneine biosynthetic process
 property_value: term_tracker_item https://github.com/geneontology/go-ontology/issues/11163 xsd:anyURI
 created_by: dph
 creation_date: 2015-03-06T15:08:51Z

--- a/src/ontology/ec_in_xref.txt
+++ b/src/ontology/ec_in_xref.txt
@@ -41131,7 +41131,7 @@ synonym: "gamma-glutamyl hercynylcysteine sulfoxide synthase" EXACT []
 xref: EC:1.14.99.50
 xref: RHEA:42672
 is_a: GO:0016705 ! oxidoreductase activity, acting on paired donors, with incorporation or reduction of molecular oxygen
-relationship: part_of GO:0052704 ! ergothioneine biosynthesis from histidine via gamma-glutamyl-hercynylcysteine sulfoxide
+relationship: part_of GO:0052699 ! ergothioneine biosynthetic process
 property_value: term_tracker_item https://github.com/geneontology/go-ontology/issues/11163 xsd:anyURI
 created_by: jl
 creation_date: 2014-12-15T11:44:54Z
@@ -68667,7 +68667,7 @@ synonym: "hercynylcysteine sulfoxide synthase" EXACT []
 xref: EC:1.14.99.51
 xref: RHEA:42704
 is_a: GO:0016705 ! oxidoreductase activity, acting on paired donors, with incorporation or reduction of molecular oxygen
-relationship: part_of GO:0140479 ! ergothioneine biosynthesis from histidine via hercynylcysteine sulfoxide synthase
+relationship: part_of GO:0052699 ! ergothioneine biosynthetic process
 property_value: term_tracker_item https://github.com/geneontology/go-ontology/issues/11163 xsd:anyURI
 created_by: dph
 creation_date: 2015-03-06T15:08:51Z

--- a/src/ontology/imports/go_taxon_constraints.owl
+++ b/src/ontology/imports/go_taxon_constraints.owl
@@ -28202,25 +28202,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/GO_0052704 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0052704">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002160"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002162"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/GO_0052907 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0052907">
@@ -37884,25 +37865,6 @@
     <!-- http://purl.obolibrary.org/obo/GO_0140446 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0140446">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002160"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4751"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002162"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4751"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GO_0140479 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0140479">
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002160"/>

--- a/src/taxon_constraints/only_in_taxon.ofn
+++ b/src/taxon_constraints/only_in_taxon.ofn
@@ -642,7 +642,6 @@ Declaration(Class(<http://purl.obolibrary.org/obo/GO_0051882>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0051960>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0052324>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0052325>))
-Declaration(Class(<http://purl.obolibrary.org/obo/GO_0052704>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0052907>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0055044>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0055045>))
@@ -863,7 +862,6 @@ Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140266>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140384>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140400>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140446>))
-Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140479>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140494>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140495>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140525>))
@@ -4188,11 +4186,6 @@ SubClassOf(<http://purl.obolibrary.org/obo/GO_0052324> ObjectAllValuesFrom(<http
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0052325> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_33090>))
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0052325> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_33090>))
 
-# Class: <http://purl.obolibrary.org/obo/GO_0052704> (<http://purl.obolibrary.org/obo/GO_0052704>)
-
-SubClassOf(<http://purl.obolibrary.org/obo/GO_0052704> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_2>))
-SubClassOf(<http://purl.obolibrary.org/obo/GO_0052704> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_2>))
-
 # Class: <http://purl.obolibrary.org/obo/GO_0052907> (<http://purl.obolibrary.org/obo/GO_0052907>)
 
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0052907> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_Union_0000004>))
@@ -5292,11 +5285,6 @@ SubClassOf(Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "PMI
 
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0140446> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_4751>))
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0140446> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_4751>))
-
-# Class: <http://purl.obolibrary.org/obo/GO_0140479> (<http://purl.obolibrary.org/obo/GO_0140479>)
-
-SubClassOf(<http://purl.obolibrary.org/obo/GO_0140479> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_4751>))
-SubClassOf(<http://purl.obolibrary.org/obo/GO_0140479> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_4751>))
 
 # Class: <http://purl.obolibrary.org/obo/GO_0140494> (<http://purl.obolibrary.org/obo/GO_0140494>)
 


### PR DESCRIPTION
**⚠️ EVALUATION ONLY - DO NOT MERGE ⚠️**

## Original Issue
[#32018: Obsoletion request: ergothioneine biosynthetic process terms](https://href.li/?https://github.com/geneontology/go-ontology/issues/32018)

## Original PR (human solution)
[#32022: Obsolete GO:0061817 endoplasmic reticulum-plasma membrane tethering](https://href.li/?https://github.com/geneontology/go-ontology/pull/32022)

## Agent Commits
- Obsolete ergothioneine pathway variants

**Note**: This PR diff shows ONLY the agent's changes. The baseline is eval_base_branch.

## Agent Response - PR Comments
## Summary

This PR addresses issue #32018 by obsoleting two ergothioneine biosynthetic pathway-variant terms that are better represented by GO-CAMs or external pathway resources:

- `GO:0052704 obsolete ergothioneine biosynthesis from histidine via gamma-glutamyl-hercynylcysteine sulfoxide`
- `GO:0140479 obsolete ergothioneine biosynthesis from histidine via hercynylcysteine sulfoxide synthase`

Both obsolete terms now use `replaced_by: GO:0052699`.

## Rationale

The retained parent `GO:0052699 ergothioneine biosynthetic process` captures the GO-level process. The child terms distinguish MetaCyc-style pathway variants by route/enzyme context, which is narrower than GO needs for process annotation and is better handled by GO-CAMs or pathway databases.

The two MetaCyc pathway variants were added to `GO:0052699` as narrower mappings:

- `MetaCyc:PWY-7255 {source="skos:narrowMatch"}` for ergothioneine biosynthesis I (bacteria)
- `MetaCyc:PWY-7550 {source="skos:narrowMatch"}` for ergothioneine biosynthesis II (fungi)

## Additional Changes

Rewired molecular function process links away from the obsolete child terms:

- `GO:0044875 gamma-glutamyl hercynylcysteine sulfoxide synthase activity` now `part_of GO:0052699`
- `GO:0061686 hercynylcysteine sulfoxide synthase activity` now `part_of GO:0052699`

Updated existing obsolete terms that referenced `GO:0052704` so they no longer point to a newly obsolete term:

- `GO:0052707` now has `consider: GO:0052699` instead of `replaced_by: GO:0052704`
- `GO:0052711` now has `consider: GO:0052699`

Removed stale only-in-taxon axioms for `GO:0052704` and `GO:0140479` from generated taxon-constraint ontology files, since obsolete terms must not have taxon constraint superclass axioms.

## Validation

- Pre-validation before edits: `make travis_build` passed.
- Post-edit validation: first run exposed stale taxon-constraint axioms on the newly obsolete terms.
- Final validation after taxon cleanup: `make travis_build` passed.

Note: direct `runoak -i amigo: associations` failed in this environment because the installed OAK stack has a `linkml`/`sssom` import mismatch. I used read-only GOlr queries for annotation impact instead.

## Annotation Impact

GOlr direct annotation check found:

- `GO:0052704`: 10 current direct annotations, including four IDA annotations from `PMID:20420449` in Mycolicibacterium smegmatis and additional ISS annotations.
- `GO:0140479`: 2 current direct annotations, including an IEA annotation to PomBase `egt1`.
- Migration target for both terms: `GO:0052699 ergothioneine biosynthetic process`.

## Checklist

- [x] PLAN: issue context reviewed and intent resolved.
- [x] PRE-VALIDATION: current ontology validated before edits.
- [x] RESEARCH: relevant PMIDs checked and summarized in uncommitted `RESEARCH.md`.
- [x] TERM-SEARCH: relevant GO terms, internal references, mappings, and taxon constraints checked.
- [x] DESIGN-PATTERNS: biosynthetic-process pattern considered; no new logical definitions added.
- [x] EDITS: terms were edited via checkout/checkin workflow.
- [x] RELATIONSHIPS: obsolete terms have no `is_a`, `relationship`, or `intersection_of`; affected MF `part_of` links were rewired to the parent.
- [x] SPECIALIZED-EDITS: obsoletion, mapping, chemical-entity, and taxon-constraint guidance applied.
- [x] METADATA: obsolete-term comments, tracker links, and replacement/consider metadata updated.
- [x] AUTOMATED-VALIDATION: final `make travis_build` passed.
- [x] REFERENCE-VALIDATION: referenced PMIDs checked with PubMed/reference cache.
- [x] CHANGES-COMMITTED: local commit created.

---
🤖 **Generated by opencode agent**
- Runtime: `opencode`
- Model: `openai/gpt-5.5`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25633594974)

## Agent Response - Issue Comments
Implemented for PR #<NN>.

Summary: obsoleted the two pathway-variant child terms `GO:0052704` and `GO:0140479`, both replaced by `GO:0052699 ergothioneine biosynthetic process`. The two MetaCyc variant pathway mappings were added to the parent as `skos:narrowMatch`, and stale internal/taxon-constraint references to the obsolete terms were removed.

---
🤖 **Generated by opencode agent**
- Runtime: `opencode`
- Model: `openai/gpt-5.5`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25633594974)

## Experiment Config
| Parameter | Value |
|-----------|-------|
| Model | `openai/gpt-5.5` |
| Agent config | `ai4curation/go-ontology-agent-config@v9:.` |
| Iteration | `1` |
| URL prefix | `https://href.li/?` |
| Base branch | `eval-base-issue-32018` |

See workflow artifacts for full agent trace.