### PR TITLE
[DO NOT MERGE] eval #32018 i:1: Obsoletion request: ergothioneine biosynthetic process terms (openai/gpt-5.5, .)

### DIFF
--- a/src/ontology/comments.txt
+++ b/src/ontology/comments.txt
@@ -3826,7 +3826,7 @@ comment: This term was obsoleted because EC obsoleted it, and there was no other
 comment: This term was obsoleted because EC obsoleted it, and there was no other evidence that this function exists.
 comment: Note that enzymes classified as EC:1.1.5.3 have several activities. They should be annotated with the terms GO:0004368, GO:0052590 and GO:0052591.
 comment: Note that enzymes classified as EC:1.1.5.3 have several activities. They should be annotated with the terms GO:0004368, GO:0052590 and GO:0052591.
-comment: The reason for obsoletion is that this term does not provide a useful distinction from its parent, GO:0052704 (because that trimethyl-His yada is present in both pathways)
+comment: The reason for obsoletion is that this term does not provide a useful distinction from ergothioneine biosynthetic process.
 comment: Class II AP endonuclease is a nuclease, but not Class I, III and IV.
 comment: In this reaction N,N'-diacetylchitobiose is deacetylated at the non-reducing residue to produce 2-acetamido-4-O-(2-amino-2-deoxy-beta-D-glucopyranosyl)-2-deoxy-D-glucose (GlcN-GlcNAc). This is in contrast to EC:3.5.1.105 in which N,N'-diacetylchitobiose is deacetylated at the reducing residue to produce 4-O-(N-acetyl-beta-D-glucosaminyl)-D-glucosamine (GlcNAc-GlcN). For the latter reaction, see GO:0036311.
 comment: EC has determined that this reaction in fact does not exist and have withdrawn EC:1.3.3.1. Note: If fumarate is not shown to be involved, you may want to consider GO:0004152, dihydroorotate dehydrogenase activity (parent term); if the reaction involves fumarate, then use GO:0052888 dihydroorotate oxidase (fumarate) activity. Details at http://sourceforge.net/p/geneontology/ontology-requests/10770/

--- a/src/ontology/ec.obo
+++ b/src/ontology/ec.obo
@@ -41131,7 +41131,7 @@ synonym: "gamma-glutamyl hercynylcysteine sulfoxide synthase" EXACT []
 xref: EC:1.14.99.50
 xref: RHEA:42672
 is_a: GO:0016705 ! oxidoreductase activity, acting on paired donors, with incorporation or reduction of molecular oxygen
-relationship: part_of GO:0052704 ! ergothioneine biosynthesis from histidine via gamma-glutamyl-hercynylcysteine sulfoxide
+relationship: part_of GO:0052699 ! ergothioneine biosynthetic process
 property_value: term_tracker_item https://github.com/geneontology/go-ontology/issues/11163 xsd:anyURI
 created_by: jl
 creation_date: 2014-12-15T11:44:54Z
@@ -68667,7 +68667,7 @@ synonym: "hercynylcysteine sulfoxide synthase" EXACT []
 xref: EC:1.14.99.51
 xref: RHEA:42704
 is_a: GO:0016705 ! oxidoreductase activity, acting on paired donors, with incorporation or reduction of molecular oxygen
-relationship: part_of GO:0140479 ! ergothioneine biosynthesis from histidine via hercynylcysteine sulfoxide synthase
+relationship: part_of GO:0052699 ! ergothioneine biosynthetic process
 property_value: term_tracker_item https://github.com/geneontology/go-ontology/issues/11163 xsd:anyURI
 created_by: dph
 creation_date: 2015-03-06T15:08:51Z

--- a/src/ontology/ec_in_xref.txt
+++ b/src/ontology/ec_in_xref.txt
@@ -41131,7 +41131,7 @@ synonym: "gamma-glutamyl hercynylcysteine sulfoxide synthase" EXACT []
 xref: EC:1.14.99.50
 xref: RHEA:42672
 is_a: GO:0016705 ! oxidoreductase activity, acting on paired donors, with incorporation or reduction of molecular oxygen
-relationship: part_of GO:0052704 ! ergothioneine biosynthesis from histidine via gamma-glutamyl-hercynylcysteine sulfoxide
+relationship: part_of GO:0052699 ! ergothioneine biosynthetic process
 property_value: term_tracker_item https://github.com/geneontology/go-ontology/issues/11163 xsd:anyURI
 created_by: jl
 creation_date: 2014-12-15T11:44:54Z
@@ -68667,7 +68667,7 @@ synonym: "hercynylcysteine sulfoxide synthase" EXACT []
 xref: EC:1.14.99.51
 xref: RHEA:42704
 is_a: GO:0016705 ! oxidoreductase activity, acting on paired donors, with incorporation or reduction of molecular oxygen
-relationship: part_of GO:0140479 ! ergothioneine biosynthesis from histidine via hercynylcysteine sulfoxide synthase
+relationship: part_of GO:0052699 ! ergothioneine biosynthetic process
 property_value: term_tracker_item https://github.com/geneontology/go-ontology/issues/11163 xsd:anyURI
 created_by: dph
 creation_date: 2015-03-06T15:08:51Z

--- a/src/ontology/imports/go_taxon_constraints.owl
+++ b/src/ontology/imports/go_taxon_constraints.owl
@@ -28202,25 +28202,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/GO_0052704 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0052704">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002160"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002162"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/GO_0052907 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0052907">
@@ -37884,25 +37865,6 @@
     <!-- http://purl.obolibrary.org/obo/GO_0140446 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0140446">
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002160"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4751"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002162"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4751"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GO_0140479 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0140479">
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002160"/>

--- a/src/taxon_constraints/only_in_taxon.ofn
+++ b/src/taxon_constraints/only_in_taxon.ofn
@@ -642,7 +642,6 @@ Declaration(Class(<http://purl.obolibrary.org/obo/GO_0051882>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0051960>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0052324>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0052325>))
-Declaration(Class(<http://purl.obolibrary.org/obo/GO_0052704>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0052907>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0055044>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0055045>))
@@ -863,7 +862,6 @@ Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140266>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140384>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140400>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140446>))
-Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140479>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140494>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140495>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0140525>))
@@ -4188,11 +4186,6 @@ SubClassOf(<http://purl.obolibrary.org/obo/GO_0052324> ObjectAllValuesFrom(<http
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0052325> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_33090>))
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0052325> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_33090>))
 
-# Class: <http://purl.obolibrary.org/obo/GO_0052704> (<http://purl.obolibrary.org/obo/GO_0052704>)
-
-SubClassOf(<http://purl.obolibrary.org/obo/GO_0052704> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_2>))
-SubClassOf(<http://purl.obolibrary.org/obo/GO_0052704> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_2>))
-
 # Class: <http://purl.obolibrary.org/obo/GO_0052907> (<http://purl.obolibrary.org/obo/GO_0052907>)
 
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0052907> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_Union_0000004>))
@@ -5292,11 +5285,6 @@ SubClassOf(Annotation(<http://www.geneontology.org/formats/oboInOwl#source> "PMI
 
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0140446> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_4751>))
 SubClassOf(<http://purl.obolibrary.org/obo/GO_0140446> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_4751>))
-
-# Class: <http://purl.obolibrary.org/obo/GO_0140479> (<http://purl.obolibrary.org/obo/GO_0140479>)
-
-SubClassOf(<http://purl.obolibrary.org/obo/GO_0140479> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002160> <http://purl.obolibrary.org/obo/NCBITaxon_4751>))
-SubClassOf(<http://purl.obolibrary.org/obo/GO_0140479> ObjectAllValuesFrom(<http://purl.obolibrary.org/obo/RO_0002162> <http://purl.obolibrary.org/obo/NCBITaxon_4751>))
 
 # Class: <http://purl.obolibrary.org/obo/GO_0140494> (<http://purl.obolibrary.org/obo/GO_0140494>)
 


### PR DESCRIPTION
**⚠️ EVALUATION ONLY - DO NOT MERGE ⚠️**

## Original Issue
[#32018: Obsoletion request: ergothioneine biosynthetic process terms](https://href.li/?https://github.com/geneontology/go-ontology/issues/32018)

## Original PR (human solution)
[#32022: Obsolete GO:0061817 endoplasmic reticulum-plasma membrane tethering](https://href.li/?https://github.com/geneontology/go-ontology/pull/32022)

## Agent Commits
- Obsolete ergothioneine pathway variant terms

**Note**: This PR diff shows ONLY the agent's changes. The baseline is eval_base_branch.

## Agent Response - PR Comments
# PR description

Addresses geneontology/go-ontology issue #32018.

## Changes made

* Obsoleted the two pathway-variant BP terms:
  * `GO:0052704 obsolete ergothioneine biosynthesis from histidine via gamma-glutamyl-hercynylcysteine sulfoxide`
  * `GO:0140479 obsolete ergothioneine biosynthesis from histidine via hercynylcysteine sulfoxide synthase`
* Both obsolete terms now use `replaced_by: GO:0052699`.
* Added the requested pathway-variant MetaCyc mappings to the broader parent as narrow matches:
  * `xref: MetaCyc:PWY-7255 {source="skos:narrowMatch"}`
  * `xref: MetaCyc:PWY-7550 {source="skos:narrowMatch"}`
* Rewired ontology-internal `part_of` links from the now-obsolete pathway variants to `GO:0052699 ergothioneine biosynthetic process`:
  * `GO:0044875 gamma-glutamyl hercynylcysteine sulfoxide synthase activity`
  * `GO:0061686 hercynylcysteine sulfoxide synthase activity`
* Updated stale obsolete-term replacement/comment references so they no longer point to `GO:0052704`.
* Removed taxon constraint axioms for the newly obsolete terms from `only_in_taxon.ofn` and the generated taxon-constraint import.
* Updated auxiliary EC/comment source files that still referenced the obsolete GO terms.

## Rationale

The two child BP terms represent pathway variants corresponding to specific MetaCyc pathways. As requested in the issue, these distinctions are better represented by pathway resources or GO-CAMs rather than separate GO process classes. The biologically appropriate GO replacement for both is the existing parent `GO:0052699 ergothioneine biosynthetic process`.

The MetaCyc pathway IDs are narrower than the GO parent process, so they were added to the parent with `skos:narrowMatch` mapping qualifiers.

## Annotation impact

Direct annotation impact was checked. The local `runoak -i amigo:` route failed due a local OAK/LinkML import error (`Format.JSON` attribute error), so GOlr was queried directly.

Current direct annotation counts found:

* `GO:0052704`: 9 direct annotations
  * 4 IDA annotations from `PMID:20420449` to Mycobacterium smegmatis EgtB/EgtC/EgtD/EgtE proteins.
  * 5 ISS annotations from `GO_REF:0000024` to orthologous mycobacterial proteins.
  * Recommended migration target: `GO:0052699 ergothioneine biosynthetic process`.
* `GO:0140479`: 1 direct IEA annotation to PomBase `SPBC1604.01/egt1`, with `GO:0061686` as evidence-with.
  * Recommended migration target: `GO:0052699 ergothioneine biosynthetic process`.

## Validation

* Pre-validation: `cd src/ontology && make travis_build` passed before edits.
* Post-edit validation: `cd src/ontology && make travis_build` passed after edits.
* Supporting reference text in `RESEARCH.md` was validated with `linkml-reference-validator validate text-file`.

## Checklist

- [x] PLAN: Issue context was analyzed and the requested obsoletion/mapping approach was clear.
- [x] PRE-VALIDATION: Ontology validated before changes with `make travis_build`.
- [x] RESEARCH: Background/reference check performed; `RESEARCH.md` created locally.
- [x] TERM-SEARCH: Relevant GO terms and internal references were searched with `obo-grep.pl`/`grep`.
- [x] DESIGN-PATTERNS: Existing biosynthetic-process pattern and obsoletion pattern reviewed; `DESIGN_PATTERNS.md` created locally.
- [x] EDITS: Terms were edited via checkout/checkin workflow for `go-edit.obo`.
- [x] RELATIONSHIPS: Obsolete terms have no asserted logical axioms; participating MF `part_of` links now point to the non-obsolete parent.
  - [x] Logical definitions: no new logical definitions were added; existing parent logical definition retained.
  - [x] Relationships conform to the issue request and avoid references to obsolete terms.
  - [x] `is_a` was removed from obsolete terms.
- [x] SPECIALIZED-EDITS:
  - [x] `/term-obsoletion` applied.
  - [x] `/mapping` applied for MetaCyc xrefs with SKOS predicates.
  - [x] `/taxon-constraint` applied to remove constraints from obsolete terms.
  - [x] `/chemical-entity` considered because the parent logical definition references ChEBI; no ChEBI edit was made.
  - [ ] `/reaction` N/A; no catalytic activity definition or RHEA/EC mapping was changed.
- [x] METADATA: Obsolete term metadata includes obsoletion comments, tracker item for issue #32018, `is_obsolete: true`, and `replaced_by: GO:0052699`.
- [x] AUTOMATED-VALIDATION: `make travis_build` passed after changes.
- [x] REFERENCE-VALIDATION: Existing PMIDs touched by the affected terms were checked; support lines in `RESEARCH.md` validated.
- [x] CHANGES-COMMITTED: Local commit created.
  - [x] RELEVANT-FILES: Only edited ontology/taxon/import auxiliary files were committed.
  - [x] ACCURACY: Changes match the biological and scope rationale in the issue.
  - [x] ISSUE-ALIGNMENT: Implements the requested obsoletion and parent-level narrow MetaCyc mappings.
  - [x] PR comments prepared here.

---
🤖 **Generated by pi agent**
- Runtime: `pi`
- Model: `openai/gpt-5.5`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25633619319)

## Agent Response - Issue Comments
Changes committed in PR #<NN>.

Summary:

* Obsoleted `GO:0052704` and `GO:0140479` as pathway-variant ergothioneine biosynthesis terms, with `replaced_by: GO:0052699`.
* Added `MetaCyc:PWY-7255` and `MetaCyc:PWY-7550` to `GO:0052699` as `skos:narrowMatch` xrefs.
* Rewired ontology-internal `part_of` links and stale replacement references to the broader parent term.
* Removed the old taxon constraint axioms from the obsolete terms.

Annotation impact checked via GOlr: current direct usages appear migratable to `GO:0052699` (9 for `GO:0052704`, 1 for `GO:0140479`).

---
🤖 **Generated by pi agent**
- Runtime: `pi`
- Model: `openai/gpt-5.5`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25633619319)

## Experiment Config
| Parameter | Value |
|-----------|-------|
| Model | `openai/gpt-5.5` |
| Agent config | `ai4curation/go-ontology-agent-config@v9:.` |
| Iteration | `1` |
| URL prefix | `https://href.li/?` |
| Base branch | `eval-base-issue-32018` |

See workflow artifacts for full agent trace.