### PR TITLE
[DO NOT MERGE] eval #31670 i:1: Taxon constraint: please add for GO:0070478 and similar terms (gpt-5.4, .)

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -664,6 +664,7 @@ GO:0140250	regulation protein catabolic process at synapse	NCBITaxon:33208	Metaz
 GO:1904381	Golgi apparatus mannose trimming	NCBITaxon:2759	Eukaryota	
 GO:1905951	mitochondrion DNA recombination	NCBITaxon:2759	Eukaryota	
 GO:1990180	mitochondrial tRNA 3'-end processing	NCBITaxon:2759	Eukaryota	
+GO:0000956	nuclear-transcribed mRNA catabolic process	NCBITaxon:2759	Eukaryota	
 GO:0000957	mitochondrial RNA catabolic process	NCBITaxon:2759	Eukaryota	
 GO:0000958	mitochondrial mRNA catabolic process	NCBITaxon:2759	Eukaryota	
 GO:0000959	mitochondrial RNA metabolic process	NCBITaxon:2759	Eukaryota	
@@ -851,6 +852,7 @@ GO:0019270	aerobactin biosynthetic process	NCBITaxon:Union_0000004	Prokaryota
 GO:0005326	neurotransmitter transmembrane transporter activity	NCBITaxon:6072	Eumetazoa	
 GO:0001775	cell activation	NCBITaxon:33208	Metazoa	
 GO:0141063	epigenetic programming in the central cell	NCBITaxon:33090	Viridiplantae	
+GO:0141065	maternal mRNA clearance	NCBITaxon:2759	Eukaryota	
 GO:0160092	hemozoin formation complex	NCBITaxon:5820	Plasmodium	
 GO:0009048	dosage compensation by inactivation of X chromosome	NCBITaxon:32524	Amniota	PMID:19802707
 GO:0080188	gene silencing by RNA-directed DNA methylation	NCBITaxon:33090	Viridiplantae	PMID:33031395


### PR DESCRIPTION
**⚠️ EVALUATION ONLY - DO NOT MERGE ⚠️**

## Original Issue
[#31670: Taxon constraint: please add for GO:0070478 and similar terms](https://href.li/?https://github.com/geneontology/go-ontology/issues/31670)

## Original PR (human solution)
[#31676: Add new GO terms for Eukaryota and Bacteria](https://href.li/?https://github.com/geneontology/go-ontology/pull/31676)

## Agent Commits
- Add eukaryote-only constraints for nuclear-transcribed and maternal mRNA decay terms

**Note**: This PR diff shows ONLY the agent's changes. The baseline is eval_base_branch.

## Agent Response - PR Comments
Summary:

Added two missing taxon constraints to `src/taxon_constraints/only_in_taxon.tsv`:
- `GO:0000956` nuclear-transcribed mRNA catabolic process -> `NCBITaxon:2759` Eukaryota
- `GO:0141065` maternal mRNA clearance -> `NCBITaxon:2759` Eukaryota

Rationale:

Issue #31670 reported bacterial annotations to `GO:0070478` nuclear-transcribed mRNA catabolic process, 3'-5' exonucleolytic nonsense-mediated decay. In this repo snapshot, the upstream-discussed parent constraint for `GO:0000956` was not yet present, so descendant terms in the nuclear-transcribed mRNA decay branch were not protected by an inherited eukaryote-only constraint. I added the missing parent-process constraint, which covers `GO:0070478` and sibling terms in that branch. I also added the missing `GO:0141065` maternal mRNA clearance constraint that had been identified in the issue discussion as another eukaryote-only mRNA decay process. `GO:0000958` mitochondrial mRNA catabolic process was already constrained in this snapshot, so no change was needed there.

Validation:

- Pre-validation: `cd src/ontology && make travis_build` passed before edits.
- Post-validation: `cd src/ontology && make travis_build` passed after edits.

Skills/workflow used:

- Used the `/taxon-constraint` skill because this is a taxon constraint edit in `src/taxon_constraints`.
- Did term lookup in `src/ontology/go-edit.obo` with `obo-grep.pl` to confirm the affected branch and similar terms.
- No `go-edit.obo` checkout/checkin was needed because taxon constraints are maintained in TSV files, not the main OBO edit file.
- No new references were introduced, so reference-validation was not applicable.
- No design-pattern work was needed because this issue did not involve new logical axioms or term creation.

Checklist:

- [x] PLAN: The issue and comments were reviewed and the requested scope was clear.
- [x] PRE-VALIDATION: Current state validated before edits.
- [ ] RESEARCH: N/A for this taxon-constraint-only change; no literature-backed definition work or new references were introduced.
- [x] TERM-SEARCH: Relevant GO terms were checked in `src/ontology/go-edit.obo`.
- [ ] DESIGN-PATTERNS: N/A; no term design or logical definition changes.
- [x] EDITS: Correct procedure followed for taxon constraints by editing `src/taxon_constraints/only_in_taxon.tsv`.
- [x] RELATIONSHIPS: Constraint applied at the appropriate parent term so descendant NMD terms inherit the eukaryote-only restriction.
- [x] SPECIALIZED-EDITS: `/taxon-constraint` skill used.
- [ ] METADATA: N/A; no term metadata changed and no new terms were created.
- [x] AUTOMATED-VALIDATION: `make travis_build` passed after changes.
- [ ] REFERENCE-VALIDATION: N/A; no references introduced.
- [x] CHANGES-COMMITTED: Relevant edited file committed locally.
- [x] RELEVANT-FILES: Only `src/taxon_constraints/only_in_taxon.tsv` was committed.
- [x] ACCURACY: Constraints align with the biology and the issue request.
- [x] ISSUE-ALIGNMENT: The change addresses the reported bacterial annotation problem for the nuclear-transcribed/NMD branch.
- [x] PR is created or amended: Local commit prepared for PR creation by the evaluation harness.
- [x] Communicate high level summary of changes on original issue(s).
- [x] Communicated on PR detailed description of changes made, and rationale.

---
🤖 **Generated by codex agent**
- Runtime: `codex`
- Model: `gpt-5.4`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25640329232)

## Agent Response - Issue Comments
Implemented locally and committed in PR #<NN>.

I added the missing `only_in_taxon Eukaryota` constraints for:
- `GO:0000956` nuclear-transcribed mRNA catabolic process
- `GO:0141065` maternal mRNA clearance

This covers the reported bacterial annotations to the nonsense-mediated decay branch via the parent nuclear-transcribed mRNA catabolic term. The existing `GO:0000958` mitochondrial mRNA catabolic process constraint was already present in this repo snapshot.

---
🤖 **Generated by codex agent**
- Runtime: `codex`
- Model: `gpt-5.4`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25640329232)

## Experiment Config
| Parameter | Value |
|-----------|-------|
| Model | `gpt-5.4` |
| Agent config | `ai4curation/go-ontology-agent-config@v9:.` |
| Iteration | `1` |
| URL prefix | `https://href.li/?` |
| Base branch | `eval-base-issue-31670` |

See workflow artifacts for full agent trace.