### PR TITLE
[DO NOT MERGE] eval #31670 i:1: Taxon constraint: please add for GO:0070478 and similar terms (haiku-4.5, .)

### DIFF
--- a/src/taxon_constraints/never_in_taxon.tsv
+++ b/src/taxon_constraints/never_in_taxon.tsv
@@ -748,3 +748,9 @@ GO:0030202	heparin proteoglycan metabolic process	NCBITaxon:4751	Fungi
 GO:0030202	heparin proteoglycan metabolic process	NCBITaxon:6656	Arthropoda	
 GO:0042339	keratan sulfate proteoglycan metabolic proces	NCBITaxon:4751	Fungi	
 GO:0042339	keratan sulfate proteoglycan metabolic proces	NCBITaxon:6656	Arthropoda	
+GO:0000184	nuclear-transcribed mRNA catabolic process, nonsense-mediated decay	NCBITaxon:2	Bacteria	
+GO:0070478	nuclear-transcribed mRNA catabolic process, 3'-5' exonucleolytic nonsense-mediated decay	NCBITaxon:2	Bacteria	
+GO:0070479	nuclear-transcribed mRNA catabolic process, 5'-3' exonucleolytic nonsense-mediated decay	NCBITaxon:2	Bacteria	
+GO:2000622	regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay	NCBITaxon:2	Bacteria	
+GO:2000623	negative regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay	NCBITaxon:2	Bacteria	
+GO:2000624	positive regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay	NCBITaxon:2	Bacteria	


### PR DESCRIPTION
**⚠️ EVALUATION ONLY - DO NOT MERGE ⚠️**

## Original Issue
[#31670: Taxon constraint: please add for GO:0070478 and similar terms](https://href.li/?https://github.com/geneontology/go-ontology/issues/31670)

## Original PR (human solution)
[#31676: Add new GO terms for Eukaryota and Bacteria](https://href.li/?https://github.com/geneontology/go-ontology/pull/31676)

## Agent Commits
- Add taxon constraints for nonsense-mediated decay (NMD) terms to bacteria

**Note**: This PR diff shows ONLY the agent's changes. The baseline is eval_base_branch.

## Agent Response - PR Comments
# Taxon Constraints for Nonsense-Mediated Decay Terms

## Completion Checklist

- [x] PLAN: Analyzed issue #31670 and identified NMD-related terms requiring taxon constraints
- [x] PRE-VALIDATION: Verified ontology validates before making changes (check_all_taxon_constraints_columns passed)
- [x] RESEARCH: Confirmed NMD is eukaryote-specific and requires nuclear compartment and spliced mRNAs
- [x] TERM-SEARCH: Located all NMD-related GO terms and their relationships
- [x] SPECIALIZED-EDITS: Used /taxon-constraint skill to plan constraint additions
- [x] METADATA: Taxon constraint format verified (5 TSV columns: GO_ID, term_name, taxon, taxon_label, source)
- [x] AUTOMATED-VALIDATION: Ran check_all_taxon_constraints_columns - passed
- [x] CHANGES-COMMITTED: Committed changes with detailed message

## Changes Made

Modified: `src/taxon_constraints/never_in_taxon.tsv`

Added 6 new taxon constraint rows for bacteria (NCBITaxon:2):

### NMD Core Terms
1. GO:0000184 - nuclear-transcribed mRNA catabolic process, nonsense-mediated decay (parent term)
2. GO:0070478 - nuclear-transcribed mRNA catabolic process, 3'-5' exonucleolytic nonsense-mediated decay (explicitly requested in issue)
3. GO:0070479 - nuclear-transcribed mRNA catabolic process, 5'-3' exonucleolytic nonsense-mediated decay (sister term)

### NMD Regulatory Terms
4. GO:2000622 - regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay
5. GO:2000623 - negative regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay
6. GO:2000624 - positive regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay

## Scientific Rationale

Nonsense-mediated decay (NMD) is an eukaryotic-specific mRNA surveillance mechanism that prevents the translation of aberrant mRNAs containing premature termination codons (PTCs). The mechanistic requirements exclude bacteria:

1. **Nuclear compartmentalization**: NMD requires a nucleus where pre-mRNA splicing occurs. Bacteria are prokaryotes without nuclei.

2. **Exon-exon junction complex (EJC)**: The canonical NMD pathway depends on EJCs deposited 20-24 nucleotides upstream of exon-exon junctions during splicing. Bacterial mRNAs are not spliced (with rare exceptions).

3. **Molecular machinery**: NMD involves eukaryote-specific proteins (UPF1, UPF2, UPF3, SMG1-6, eRFC1/3) that evolved in eukaryotes and have no functional homologs in bacteria.

4. **Biological context**: The addressed issue noted that PANTHER incorrectly annotated bacteria with these terms, indicating a genuine problem in annotation curation pipelines.

## Validation

- File format: Verified all TSV columns are consistent (5 columns per row)
- No syntax errors: check_all_taxon_constraints_columns target passed
- Term existence: Confirmed all GO IDs exist in src/ontology/go-edit.obo
- Taxon validity: NCBITaxon:2 (Bacteria) is the correct general taxon for prokaryotic bacteria
- No duplicates: These constraints are new entries with no prior existence in never_in_taxon.tsv

## Notes

The parent-child relationships among these terms remain intact:
- GO:0000184 is_a GO:0000956 (nuclear-transcribed mRNA catabolic process)
- GO:0070478 and GO:0070479 are_a GO:0000184
- GO:2000622/623/624 regulate GO:0000184

These constraints are inherited by child terms through the reasoner, ensuring comprehensive coverage for annotation quality control.

---
🤖 **Generated by claude agent**
- Runtime: `claude`
- Model: `claude-haiku-4-5-20251001`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25640380443)

## Agent Response - Issue Comments
Thank you for raising this issue. I've addressed the request by adding never_in_taxon constraints for GO:0070478 and other related nonsense-mediated decay (NMD) terms to prevent bacterial annotations, since bacteria lack the nuclear compartment and NMD machinery.

## Summary of Changes

Added never_in_taxon constraints for bacteria (NCBITaxon:2) to the following NMD-related terms:

- GO:0000184: nuclear-transcribed mRNA catabolic process, nonsense-mediated decay
- GO:0070478: nuclear-transcribed mRNA catabolic process, 3'-5' exonucleolytic nonsense-mediated decay (as you specifically requested)
- GO:0070479: nuclear-transcribed mRNA catabolic process, 5'-3' exonucleolytic nonsense-mediated decay
- GO:2000622: regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay
- GO:2000623: negative regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay
- GO:2000624: positive regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay

## Rationale

All these terms are specific to the eukaryotic nonsense-mediated decay pathway, which:
- Requires a eukaryotic nucleus (bacterial cells are prokaryotes without nuclei)
- Relies on the EJC (exon-exon junction complex) marking mechanism specific to spliced eukaryotic mRNAs
- Involves UPF proteins and other eukaryote-specific machinery

These constraints will prevent incorrect annotations from PANTHER and other sources from propagating to bacterial species.

Changes committed in PR <NN>.

---
🤖 **Generated by claude agent**
- Runtime: `claude`
- Model: `claude-haiku-4-5-20251001`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25640380443)

## Experiment Config
| Parameter | Value |
|-----------|-------|
| Model | `claude-haiku-4-5-20251001` |
| Agent config | `ai4curation/go-ontology-agent-config@v9:.` |
| Iteration | `1` |
| URL prefix | `https://href.li/?` |
| Base branch | `eval-base-issue-31670` |

See workflow artifacts for full agent trace.