### PR TITLE
[DO NOT MERGE] eval #32018 i:1: Obsoletion request: ergothioneine biosynthetic process terms (gpt-5.4, .)

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -742,8 +742,6 @@ GO:0006836	neurotransmitter transport	NCBITaxon:33208	Metazoa
 GO:0140446	fumigermin biosynthetic process	NCBITaxon:4751	Fungi	
 GO:0036411	H-NS-Cnu complex	NCBITaxon:2	Bacteria	
 GO:1990198	ModE complex	NCBITaxon:2	Bacteria	
-GO:0052704	ergothioneine biosynthesis from histidine via gamma-glutamyl-hercynylcysteine sulfoxide	NCBITaxon:2	Bacteria	
-GO:0140479	ergothioneine biosynthesis from histidine via hercynylcysteine sulfoxide synthase	NCBITaxon:4751	Fungi	
 GO:0140495	migracytosis	NCBITaxon:7742	Vertebrata <Metazoa>	
 GO:0120259	7SK snRNP	NCBITaxon:33208	Metazoa	
 GO:0120260	ciliary microtubule quartet	NCBITaxon:5653	Kinetoplastida	


### PR DESCRIPTION
**⚠️ EVALUATION ONLY - DO NOT MERGE ⚠️**

## Original Issue
[#32018: Obsoletion request: ergothioneine biosynthetic process terms](https://href.li/?https://github.com/geneontology/go-ontology/issues/32018)

## Original PR (human solution)
[#32021: Update only_in_taxon.tsv](https://href.li/?https://github.com/geneontology/go-ontology/pull/32021)

## Agent Commits
- Obsolete ergothioneine pathway variant terms

**Note**: This PR diff shows ONLY the agent's changes. The baseline is eval_base_branch.

## Agent Response - PR Comments
This PR obsoletes the two ergothioneine pathway-variant BP terms requested in issue #32018 and folds their external pathway mappings into the broader parent process.

Changes made:
- Obsoleted `GO:0052704 ergothioneine biosynthesis from histidine via gamma-glutamyl-hercynylcysteine sulfoxide`
  - `replaced_by: GO:0052699`
- Obsoleted `GO:0140479 ergothioneine biosynthesis from histidine via hercynylcysteine sulfoxide synthase`
  - `replaced_by: GO:0052699`
- Added parent-level pathway mappings to `GO:0052699 ergothioneine biosynthetic process`
  - `xref: MetaCyc:PWY-7255 {source="skos:narrowMatch"}`
  - `xref: MetaCyc:PWY-7550 {source="skos:narrowMatch"}`
- Rewired GO-internal usage before obsoletion
  - `GO:0044875` `part_of GO:0052699`
  - `GO:0061686` `part_of GO:0052699`
- Removed obsolete-term taxon constraints from `src/taxon_constraints/only_in_taxon.tsv`
  - deleted bacterial-only TC for `GO:0052704`
  - deleted fungal-only TC for `GO:0140479`
- Updated the downstream obsolete replacement on `GO:0052707` from `GO:0052704` to `GO:0052699`

Rationale:
- The two child BP terms encode lineage-/route-specific pathway variants that are better represented as external pathway mappings or in GO-CAM context than as separate GO biological process terms for direct annotation.
- The stable GO class here is the broader `GO:0052699 ergothioneine biosynthetic process`.
- The MetaCyc pathway classes are narrower than that GO class, so `skos:narrowMatch` on the parent is the appropriate mapping semantics.

Validation and research notes:
- Pre-validation passed with `cd src/ontology && make travis_build`
- Post-edit validation passed with `cd src/ontology && make travis_build`
- The taxon-constraint import had to be rebuilt after editing `src/taxon_constraints/only_in_taxon.tsv`; otherwise `travis_build` reused a stale `imports/go_taxon_constraints.owl`
- Temporary research/design notes were prepared in `RESEARCH.md` and `DESIGN_PATTERNS.md` and are not committed

Environment limitations encountered:
- `runoak -i amigo: associations GO:0052704` and `GO:0140479` could not be used for direct annotation impact analysis because the local `runoak` installation fails during import
- `linkml-reference-validator cache reference PMID:...` hit NCBI HTTP 429 in this environment, so PMID validation was limited to the existing issue context and term provenance rather than cached local reference records

Checklist:
- [x] PLAN: The issue and context were analyzed and the intent was clear
- [x] PRE-VALIDATION: Current ontology state validated before edits
- [x] RESEARCH: Background review documented in `RESEARCH.md`
- [x] TERM-SEARCH: Relevant GO terms and internal usages were checked with `obo-grep.pl`/`rg`
- [x] DESIGN-PATTERNS: Relevant pattern/precedent review documented in `DESIGN_PATTERNS.md`
- [x] EDITS: Used checkout/edit/checkin workflow for ontology terms
- [x] RELATIONSHIPS: Removed obsolete-term references and rewired valid `part_of` relations to the parent
- [x] logical definitions are appropriate and not over-specified
- [x] relationships conform to similar ergothioneine terms in the ontology
- [x] is_a is not over-asserted
- [x] is_a, part_of, and other relationships specified appropriately
- [x] SPECIALIZED-EDITS: term obsoletion handled
- [x] SPECIALIZED-EDITS: chemical-entity considerations checked for the ergothioneine parent term
- [x] SPECIALIZED-EDITS: mapping semantics checked for MetaCyc xrefs
- [x] SPECIALIZED-EDITS: taxon constraints removed from obsolete terms
- [x] METADATA: obsoletion metadata and term tracker links updated appropriately
- [x] AUTOMATED-VALIDATION: `make travis_build` passed after changes
- [x] REFERENCE-VALIDATION: existing reference IDs were retained; no new PMIDs were introduced
- [x] CHANGES-COMMITTED
- [x] RELEVANT-FILES: committed source changes in `src/ontology/go-edit.obo` and `src/taxon_constraints/only_in_taxon.tsv`
- [x] ACCURACY: changes align with the issue rationale and internal ontology precedent
- [x] ISSUE-ALIGNMENT: work is consistent with the request to obsolete the two pathway-variant terms
- [x] PR is created or amended
- [x] Communicate high level summary of changes on original issue(s)
- [x] Communicated on PR detailed description of changes made, and rationale

---
🤖 **Generated by codex agent**
- Runtime: `codex`
- Model: `gpt-5.4`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25640341584)

## Agent Response - Issue Comments
Implemented in PR #<NN>.

Summary:
- obsoleted `GO:0052704` and `GO:0140479`, both replaced by `GO:0052699 ergothioneine biosynthetic process`
- rewired the associated MF `part_of` links to the parent process
- added `MetaCyc:PWY-7255` and `MetaCyc:PWY-7550` to `GO:0052699` as `skos:narrowMatch`
- removed the corresponding `only_in_taxon` constraints from the obsolete terms

One downstream cleanup was needed as part of the obsoletion: `GO:0052707` had previously been obsoleted with `replaced_by GO:0052704`, so that replacement now points to `GO:0052699`.

Validation:
- `cd src/ontology && make travis_build` passed after rebuilding the taxon-constraint import from the updated TSV

Environment note:
- direct AmiGO annotation lookup via `runoak -i amigo: associations ...` was not available in this workspace because the local `runoak` install errors at import time

---
🤖 **Generated by codex agent**
- Runtime: `codex`
- Model: `gpt-5.4`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25640341584)

## Experiment Config
| Parameter | Value |
|-----------|-------|
| Model | `gpt-5.4` |
| Agent config | `ai4curation/go-ontology-agent-config@v9:.` |
| Iteration | `1` |
| URL prefix | `https://href.li/?` |
| Base branch | `eval-base-issue-32018` |

See workflow artifacts for full agent trace.