### PR TITLE
[DO NOT MERGE] eval #31051 i:1: Taxon constraint: GO:0046544 development of secondary male sexual characteristics (togetherai/moonshotai/Kimi-K2.6, .)

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -378,7 +378,7 @@ GO:0044782	cilium organization	NCBITaxon:2759	Eukaryota
 GO:0044787	bacterial-type DNA replication	NCBITaxon:2	Bacteria	
 GO:0044849	estrous cycle	NCBITaxon:32525	Theria <Mammalia>	
 GO:0044850	menstrual cycle	NCBITaxon:9443	Primates	
-GO:0045136	development of secondary sexual characteristics, sensu Metazoa	NCBITaxon:33208	Metazoa	https://github.com/geneontology/go-ontology/issues/31051
+GO:0045136	development of animal secondary sexual characteristics	NCBITaxon:33208	Metazoa	https://github.com/geneontology/go-ontology/issues/31051
 GO:0045138	nematode male tail tip morphogenesis	NCBITaxon:6231	Nematoda	
 GO:0045152	antisigma factor binding	NCBITaxon:2	Bacteria	
 GO:0045170	spectrosome	NCBITaxon:6656	Arthropoda	


### PR DESCRIPTION
**⚠️ EVALUATION ONLY - DO NOT MERGE ⚠️**

## Original Issue
[#31051: Taxon constraint: GO:0046544 development of secondary male sexual characteristics](https://href.li/?https://github.com/geneontology/go-ontology/issues/31051)

## Original PR (human solution)
[#32037: Issue #31051: rename secondary sexual characteristic terms with 'animal' prefix](https://href.li/?https://github.com/geneontology/go-ontology/pull/32037)

## Agent Commits
- Rename secondary sexual characteristics terms from 'sensu Metazoa' to 'animal' for consistency

**Note**: This PR diff shows ONLY the agent's changes. The baseline is eval_base_branch.

## Agent Response - PR Comments
## Summary

Renames three GO terms in response to the discussion on #31051, specifically implementing @pgaudet's suggestion to use "animal" rather than "sensu Metazoa" for consistency with existing GO naming conventions (e.g. [animal organ development](https://github.com/geneontology/go-ontology/issues/25943)).

## Changes made

### GO:0045136
- **Old name:** development of secondary sexual characteristics, sensu Metazoa
- **New name:** development of animal secondary sexual characteristics
- Added RELATED synonym: "development of secondary sexual characteristics, sensu Metazoa"

### GO:0046543
- **Old name:** development of secondary female sexual characteristics, sensu Metazoa
- **New name:** development of animal secondary female sexual characteristics
- Added RELATED synonym: "development of secondary female sexual characteristics, sensu Metazoa"

### GO:0046544
- **Old name:** development of secondary male sexual characteristics, sensu Metazoa
- **New name:** development of animal secondary male sexual characteristics
- Added RELATED synonym: "development of secondary male sexual characteristics, sensu Metazoa"

### GO:0042695 (thelarche)
- Updated `is_a` comment label to reflect new parent name (no semantic change)

### Taxon constraints
- Updated `only_in_taxon.tsv` label for GO:0045136 to match the new term name

## Rationale

The previous PR (#32027) renamed these terms using the "sensu Metazoa" suffix to clarify their animal-specific scope while avoiding over-assertion of homology. However, @pgaudet noted that GO already uses "animal" as a naming convention for similar scoping (e.g. "animal organ development" vs "plant organ development"). Switching to "animal" improves consistency, makes the terms more discoverable to biologists, and avoids the subtle ontological implications that "sensu" can carry.

Both original labels (without any qualifier) and the intermediate "sensu Metazoa" labels are preserved as synonyms so all existing lookups remain functional:
- Original (e.g. "development of secondary sexual characteristics") -> EXACT synonym
- Intermediate (e.g. "development of secondary sexual characteristics, sensu Metazoa") -> RELATED synonym

The taxon constraint (`only_in_taxon Metazoa`) on the parent GO:0045136, which propagates to the children, was already in place from the previous PR. Only the label in `only_in_taxon.tsv` needed updating.

## Agent checklist

- [x] PLAN: The issue and all its context has been analyzed, the intent is clear, and a plan for addressing it has been created
- [x] PRE-VALIDATION: Current state of the ontology validates prior to any changes (robot convert passes)
- [x] TERM-SEARCH: Relevant ontology terms consulted
- [x] EDITS: correct procedure followed for making edits, using checkin/checkout commands and local `./terms/` folder
- [x] RELATIONSHIPS: appropriate relationships preserved; is_a comment labels updated where needed
- [x] METADATA: The metadata for the changes is correct (synonyms added, term_tracker_item preserved)
- [x] AUTOMATED-VALIDATION: `robot convert` passes successfully after changes; OBO syntax is valid
- [x] REFERENCE-VALIDATION: No new PMIDs/references introduced; existing references preserved
- [x] CHANGES-COMMITTED: Changes to `src/ontology/go-edit.obo` and `src/taxon_constraints/only_in_taxon.tsv` committed with detailed messages

---
🤖 **Generated by opencode agent**
- Runtime: `opencode`
- Model: `togetherai/moonshotai/Kimi-K2.6`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25646680440)

## Agent Response - Issue Comments
Hi all,

Following @pgaudet's request, I have renamed the three terms to use "animal" rather than "sensu Metazoa" for consistency with existing GO conventions (e.g. "animal organ development"). The changes are committed in PR #<NN>.

Summary:
- GO:0045136 -> development of animal secondary sexual characteristics
- GO:0046543 -> development of animal secondary female sexual characteristics
- GO:0046544 -> development of animal secondary male sexual characteristics

Original labels are preserved as EXACT synonyms, and the intermediate "sensu Metazoa" labels are kept as RELATED synonyms for searchability. The taxon constraint in only_in_taxon.tsv was also updated.

Please review the PR for full details.

---
🤖 **Generated by opencode agent**
- Runtime: `opencode`
- Model: `togetherai/moonshotai/Kimi-K2.6`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25646680440)

## Experiment Config
| Parameter | Value |
|-----------|-------|
| Model | `togetherai/moonshotai/Kimi-K2.6` |
| Agent config | `ai4curation/go-ontology-agent-config@v9:.` |
| Iteration | `1` |
| URL prefix | `https://href.li/?` |
| Base branch | `eval-base-issue-31051` |

See workflow artifacts for full agent trace.