### PR TITLE
[DO NOT MERGE] eval #31670 i:1: Taxon constraint: please add for GO:0070478 and similar terms (togetherai/moonshotai/Kimi-K2.6, .)

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -951,3 +951,5 @@ GO:0019905	syntaxin binding	NCBITaxon:2	Bacteria
 GO:0098795	global gene silencing by mRNA cleavage	NCBITaxon:2	Bacteria	
 GO:0140400	embryonic sheath	NCBITaxon:6231	Nematoda	PMID:28526752
 GO:0019658	bifid shunt	NCBITaxon:2	Bacteria	
+GO:0000956	nuclear-transcribed mRNA catabolic process	NCBITaxon:2759	Eukaryota	
+GO:0141065	maternal mRNA clearance	NCBITaxon:2759	Eukaryota	


### PR DESCRIPTION
**⚠️ EVALUATION ONLY - DO NOT MERGE ⚠️**

## Original Issue
[#31670: Taxon constraint: please add for GO:0070478 and similar terms](https://href.li/?https://github.com/geneontology/go-ontology/issues/31670)

## Original PR (human solution)
[#31676: Add new GO terms for Eukaryota and Bacteria](https://href.li/?https://github.com/geneontology/go-ontology/pull/31676)

## Agent Commits
- Add taxon constraints for nuclear-transcribed mRNA catabolic process and maternal mRNA clearance

**Note**: This PR diff shows ONLY the agent's changes. The baseline is eval_base_branch.

## Agent Response - PR Comments
## Summary

Added `only_in_taxon NCBITaxon:2759 Eukaryota` constraints for:

- `GO:0000956 nuclear-transcribed mRNA catabolic process`
- `GO:0141065 maternal mRNA clearance`

## Rationale

The issue reported that bacteria were being annotated with `GO:0070478 nuclear-transcribed mRNA catabolic process, 3'-5' exonucleolytic nonsense-mediated decay`, which is biologically impossible as bacteria lack nuclei and nonsense-mediated decay machinery.

Instead of adding a `never_in_taxon Bacteria` entry to the leaf term `GO:0070478`, the most parsimonious fix is to constrain the parent term `GO:0000956` to Eukaryota. This automatically covers all of its subclasses, including NMD (`GO:0000184`, `GO:0070478`), deadenylation-dependent decay (`GO:0000288`), non-stop decay (`GO:0070481`), no-go decay (`GO:0070966`), histone mRNA catabolism (`GO:0071044`), and nuclear mRNA surveillance (`GO:0071028`).

`GO:0141065 maternal mRNA clearance` was also added as it is a eukaryote-specific process (maternal mRNA in zygotes); this aligns with the partial list proposed by pgaudet in the issue thread.

Note that `GO:0000958 mitochondrial mRNA catabolic process` already had an `only_in_taxon Eukaryota` constraint in the file at the time of editing, so this change keeps the family of mRNA catabolism terms consistent.

## Checklist

- [x] Issue context and intent analyzed.
- [x] Taxon-constraint skill consulted.
- [x] Existing taxon constraint files searched for duplicates / pre-existing constraints.
- [x] GO:0000956 confirmed in ontology; children verified to be eukaryote-specific.
- [x] No duplicate entries introduced.
- [x] `make check_all_taxon_constraints_columns` passed.
- [ ] Full `make travis_build` could not be run because `amm` and `robot` are not present in this environment. The change is a minimal, safe TSV addition.

---
🤖 **Generated by opencode agent**
- Runtime: `opencode`
- Model: `togetherai/moonshotai/Kimi-K2.6`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25646686906)

## Agent Response - Issue Comments
Hi,

Thanks for reporting this. I've added `only_in_taxon Eukaryota` constraints to `GO:0000956` (nuclear-transcribed mRNA catabolic process) and `GO:0141065` (maternal mRNA clearance). Constraining `GO:0000956` covers `GO:0070478` and all related nuclear-transcribed mRNA decay pathways (NMD, deadenylation-dependent decay, no-go decay, non-stop decay, etc.), as these are inherently eukaryotic processes.

Changes committed in PR #<NN>.

---
🤖 **Generated by opencode agent**
- Runtime: `opencode`
- Model: `togetherai/moonshotai/Kimi-K2.6`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25646686906)

## Experiment Config
| Parameter | Value |
|-----------|-------|
| Model | `togetherai/moonshotai/Kimi-K2.6` |
| Agent config | `ai4curation/go-ontology-agent-config@v9:.` |
| Iteration | `1` |
| URL prefix | `https://href.li/?` |
| Base branch | `eval-base-issue-31670` |

See workflow artifacts for full agent trace.