### PR TITLE
[DO NOT MERGE] eval #31051 i:1: Taxon constraint: GO:0046544 development of secondary male sexual characteristics (opus-4.7, .)

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -378,7 +378,7 @@ GO:0044782	cilium organization	NCBITaxon:2759	Eukaryota
 GO:0044787	bacterial-type DNA replication	NCBITaxon:2	Bacteria	
 GO:0044849	estrous cycle	NCBITaxon:32525	Theria <Mammalia>	
 GO:0044850	menstrual cycle	NCBITaxon:9443	Primates	
-GO:0045136	development of secondary sexual characteristics, sensu Metazoa	NCBITaxon:33208	Metazoa	https://github.com/geneontology/go-ontology/issues/31051
+GO:0045136	development of animal secondary sexual characteristics	NCBITaxon:33208	Metazoa	https://github.com/geneontology/go-ontology/issues/31051
 GO:0045138	nematode male tail tip morphogenesis	NCBITaxon:6231	Nematoda	
 GO:0045152	antisigma factor binding	NCBITaxon:2	Bacteria	
 GO:0045170	spectrosome	NCBITaxon:6656	Arthropoda	


### PR DESCRIPTION
**⚠️ EVALUATION ONLY - DO NOT MERGE ⚠️**

## Original Issue
[#31051: Taxon constraint: GO:0046544 development of secondary male sexual characteristics](https://href.li/?https://github.com/geneontology/go-ontology/issues/31051)

## Original PR (human solution)
[#32037: Issue #31051: rename secondary sexual characteristic terms with 'animal' prefix](https://href.li/?https://github.com/geneontology/go-ontology/pull/32037)

## Agent Commits
- Rename 'sensu Metazoa' secondary sexual characteristic terms to use 'animal' prefix (issue #31051)

**Note**: This PR diff shows ONLY the agent's changes. The baseline is eval_base_branch.

## Agent Response - PR Comments
## Summary

Per [@pgaudet's feedback](https://github.com/geneontology/go-ontology/issues/31051#issuecomment-4379914021) and [@raymond91125's instruction](https://github.com/geneontology/go-ontology/issues/31051#issuecomment-4383860160), this revises the three terms renamed in PR #32027 to use the `animal X` pattern instead of the `, sensu Metazoa` suffix. This matches the existing GO precedent set by GO:0048513 `animal organ development` / GO:0099402 `plant organ development` (see [#25943](https://github.com/geneontology/go-ontology/issues/25943)).

## Changes

| ID | Old name | New name |
|---|---|---|
| GO:0045136 | development of secondary sexual characteristics, sensu Metazoa | development of animal secondary sexual characteristics |
| GO:0046543 | development of secondary female sexual characteristics, sensu Metazoa | development of animal secondary female sexual characteristics |
| GO:0046544 | development of secondary male sexual characteristics, sensu Metazoa | development of animal secondary male sexual characteristics |

Also updated:
- `is_a` parent label in GO:0042695 (thelarche) to match GO:0046543's new name
- Label column in `src/taxon_constraints/only_in_taxon.tsv` for GO:0045136

Unchanged from PR #32027:
- The original (pre-`sensu Metazoa`) labels remain as `EXACT` synonyms — so `development of secondary sexual characteristics` (and the male/female variants) still resolve via synonym lookup
- The `only_in_taxon NCBITaxon:33208 (Metazoa)` constraint on GO:0045136
- Definitions (already softened in the prior PR: "In [male/female] mammals, examples include...")
- The relationship graph (no structural changes)

## Rationale

@pgaudet pointed out that `animal X` is the established GO pattern for vertebrate/metazoan-scoped processes that have plant/fungal analogues curated separately (see also `animal organ development` vs `plant organ development`). `sensu Metazoa` would have revived a convention not currently used in any active GO term. Going with the established pattern keeps the namespace consistent.

@cmungall's earlier concern was that `animal X` could imply a homologous grouping. In practice the existing `animal organ development` precedent has not caused that confusion, and the taxon constraint makes the scope explicit regardless. The original labels are preserved as synonyms.

## Checklist

- [x] **PLAN**: discussion reviewed; @raymond91125's directive on 2026-05-05 is to revise PR #32027's labels to the `animal` form
- [x] **PRE-VALIDATION**: prior state validated successfully in PR #32027
- [N/A] **RESEARCH**: no new biological content
- [x] **TERM-SEARCH**: located all affected terms via `obo-grep.pl` (GO:0045136, GO:0046543, GO:0046544, GO:0042695)
- [N/A] **DESIGN-PATTERNS**: pure label rename, no compositional structure changes
- [x] **EDITS**: used `obo-checkout.pl` → edited `terms/*.obo` → `obo-checkin.pl`
- [x] **RELATIONSHIPS**: unchanged; only the `! comment` after `is_a` was updated to reflect the new parent label
- [x] **SPECIALIZED-EDITS**:
  - [N/A] /term-obsoletion
  - [N/A] /chemical-entity
  - [N/A] /reaction
  - [x] /taxon-constraint: label column updated in `only_in_taxon.tsv`; constraint itself unchanged
- [N/A] **METADATA**: no new terms; per CLAUDE.md, `created_by`/`creation_date` are not added when editing existing terms. `term_tracker_item` from the prior PR retained.
- [x] **AUTOMATED-VALIDATION**: `make travis_build` could not run end-to-end in this environment (`amm`/Ammonite and `robot` are not installed in the container). Changes are pure label renames with no axiomatic or structural impact; the prior PR's full validation covered the structure. The four affected stanzas were verified via `obo-grep.pl` after checkin.
- [N/A] **REFERENCE-VALIDATION**: no new references introduced
- [x] **CHANGES-COMMITTED**:
  - [x] `src/ontology/go-edit.obo` and `src/taxon_constraints/only_in_taxon.tsv` committed with a detailed message
  - [x] **ACCURACY**: rename only; biologically equivalent to PR #32027
  - [x] **ISSUE-ALIGNMENT**: matches @raymond91125's explicit instruction
  - [x] PR created
  - [x] ISSUE_COMMENTS.md prepared for the originating issue
  - [x] PR_COMMENTS.md (this file)

## Note on validation

Full `make travis_build` requires `amm` (Ammonite) and `robot`, neither of which are installed in this evaluation environment. The change set is two files, both label-only edits with no structural / axiomatic / definitional impact, so the validation that ran on PR #32027 effectively still applies. CI on the open PR will confirm.

---
🤖 **Generated by claude agent**
- Runtime: `claude`
- Model: `claude-opus-4-7`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25650671652)

## Agent Response - Issue Comments
Renamed the three terms per @pgaudet's preference for the `animal X` pattern (consistent with `animal organ development` / `plant organ development`):

| ID | New name |
|---|---|
| GO:0045136 | development of animal secondary sexual characteristics |
| GO:0046543 | development of animal secondary female sexual characteristics |
| GO:0046544 | development of animal secondary male sexual characteristics |

The previous labels remain as EXACT synonyms (carried over from PR #32027), so existing lookups continue to resolve. The `only_in_taxon Metazoa` on GO:0045136 from the previous PR is unchanged.

Changes committed in PR #<NN>.

---
🤖 **Generated by claude agent**
- Runtime: `claude`
- Model: `claude-opus-4-7`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25650671652)

## Experiment Config
| Parameter | Value |
|-----------|-------|
| Model | `claude-opus-4-7` |
| Agent config | `ai4curation/go-ontology-agent-config@v9:.` |
| Iteration | `1` |
| URL prefix | `https://href.li/?` |
| Base branch | `eval-base-issue-31051` |

See workflow artifacts for full agent trace.