### PR TITLE
[DO NOT MERGE] eval #31670 i:1: Taxon constraint: please add for GO:0070478 and similar terms (copilot/claude-sonnet-4.5, .)

### DIFF
--- a/src/taxon_constraints/never_in_taxon.tsv
+++ b/src/taxon_constraints/never_in_taxon.tsv
@@ -748,3 +748,10 @@ GO:0030202	heparin proteoglycan metabolic process	NCBITaxon:4751	Fungi
 GO:0030202	heparin proteoglycan metabolic process	NCBITaxon:6656	Arthropoda	
 GO:0042339	keratan sulfate proteoglycan metabolic proces	NCBITaxon:4751	Fungi	
 GO:0042339	keratan sulfate proteoglycan metabolic proces	NCBITaxon:6656	Arthropoda	
+GO:0000184	nuclear-transcribed mRNA catabolic process, nonsense-mediated decay	NCBITaxon:2	Bacteria	
+GO:0070478	nuclear-transcribed mRNA catabolic process, 3'-5' exonucleolytic nonsense-mediated decay	NCBITaxon:2	Bacteria	
+GO:0070479	nuclear-transcribed mRNA catabolic process, 5'-3' exonucleolytic nonsense-mediated decay	NCBITaxon:2	Bacteria	
+GO:0170010	nonsense-mediated decay complex	NCBITaxon:2	Bacteria	
+GO:2000622	regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay	NCBITaxon:2	Bacteria	
+GO:2000623	negative regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay	NCBITaxon:2	Bacteria	
+GO:2000624	positive regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay	NCBITaxon:2	Bacteria	


### PR DESCRIPTION
**⚠️ EVALUATION ONLY - DO NOT MERGE ⚠️**

## Original Issue
[#31670: Taxon constraint: please add for GO:0070478 and similar terms](https://href.li/?https://github.com/geneontology/go-ontology/issues/31670)

## Original PR (human solution)
[#31676: Add new GO terms for Eukaryota and Bacteria](https://href.li/?https://github.com/geneontology/go-ontology/pull/31676)

## Agent Commits
- Add never_in_taxon constraints for nonsense-mediated decay terms

**Note**: This PR diff shows ONLY the agent's changes. The baseline is eval_base_branch.

## Agent Response - PR Comments
# Taxon Constraints for Nonsense-Mediated Decay Terms

## Summary

Added `never_in_taxon: NCBITaxon:2 (Bacteria)` constraints for GO:0070478 and all related nonsense-mediated decay (NMD) terms in response to issue #31670.

## Background

The issue reported that bacterial gene products were incorrectly annotated with GO:0070478 (nuclear-transcribed mRNA catabolic process, 3'-5' exonucleolytic nonsense-mediated decay) via PANTHER annotations. This is biologically incorrect because:

1. **Bacteria lack nuclei** - NMD specifically applies to nuclear-transcribed mRNAs
2. **Bacteria lack the NMD pathway** - NMD is a eukaryotic-specific mRNA quality control mechanism

## Changes Made

Modified `src/taxon_constraints/never_in_taxon.tsv` to add seven new constraints:

### Biological Process Terms
1. **GO:0000184** - nuclear-transcribed mRNA catabolic process, nonsense-mediated decay (parent term)
2. **GO:0070478** - nuclear-transcribed mRNA catabolic process, 3'-5' exonucleolytic nonsense-mediated decay (requested term)
3. **GO:0070479** - nuclear-transcribed mRNA catabolic process, 5'-3' exonucleolytic nonsense-mediated decay (sibling pathway)
4. **GO:2000622** - regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay
5. **GO:2000623** - negative regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay
6. **GO:2000624** - positive regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay

### Cellular Component Term
7. **GO:0170010** - nonsense-mediated decay complex

## Validation

✅ All terms searched and identified using `obo-grep.pl`
✅ Comprehensive coverage - included parent term, both directional variants, regulatory terms, and the protein complex
✅ Full ontology validation passed via `make travis_build`:
  - All SPARQL verification checks passed (0 violations)
  - ELK reasoning completed successfully
  - No syntax errors or structural issues

## Checklist

- [x] PLAN: Issue analyzed and plan created
- [x] PRE-VALIDATION: N/A - only editing taxon constraint file, not ontology itself
- [x] RESEARCH: N/A - straightforward biological constraint based on well-established biology
- [x] TERM-SEARCH: All NMD-related terms identified using obo-grep.pl
- [x] DESIGN-PATTERNS: N/A - taxon constraints follow established format
- [x] EDITS: N/A - no term edits, only constraint file modification
- [x] RELATIONSHIPS: N/A - no relationship changes
- [x] SPECIALIZED-EDITS: /taxon-constraint skill applied
- [x] METADATA: N/A - no term metadata changes
- [x] AUTOMATED-VALIDATION: Full travis_build passed
- [x] REFERENCE-VALIDATION: N/A - no new references added
- [x] CHANGES-COMMITTED:
  - [x] RELEVANT-FILES: Only src/taxon_constraints/never_in_taxon.tsv modified
  - [x] ACCURACY: Biologically correct - bacteria lack nuclei and NMD machinery
  - [x] ISSUE-ALIGNMENT: Addresses requested term plus comprehensive coverage of all related terms
  - [x] PR created with detailed description
  - [x] Issue communication prepared
  - [x] PR communication includes complete checklist

## Rationale

Applied constraints comprehensively to the entire NMD term branch rather than just the specifically requested term (GO:0070478). This prevents future annotation errors across all NMD-related processes and ensures logical consistency, as:
- The parent term (GO:0000184) and both directional variants (GO:0070478, GO:0070479) are all equally inapplicable to bacteria
- Regulatory processes cannot exist without the process they regulate
- The protein complex cannot exist in organisms that lack the pathway

All changes validated successfully with no errors or warnings.

---
🤖 **Generated by copilot agent**
- Runtime: `copilot`
- Model: `claude-sonnet-4.5`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25774200725)

## Agent Response - Issue Comments
Taxon constraints have been added for GO:0070478 and all related nonsense-mediated decay terms as requested. Changes committed in PR #<NN>.

The following terms now have `never_in_taxon: NCBITaxon:2 (Bacteria)` constraints:
- GO:0000184 nuclear-transcribed mRNA catabolic process, nonsense-mediated decay (parent term)
- GO:0070478 nuclear-transcribed mRNA catabolic process, 3'-5' exonucleolytic nonsense-mediated decay (specifically requested)
- GO:0070479 nuclear-transcribed mRNA catabolic process, 5'-3' exonucleolytic nonsense-mediated decay (sibling term)
- GO:0170010 nonsense-mediated decay complex (cellular component)
- GO:2000622 regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay
- GO:2000623 negative regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay
- GO:2000624 positive regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay

This comprehensively prevents bacterial annotations for all NMD-related processes, as bacteria lack both nuclei and the NMD machinery.

---
🤖 **Generated by copilot agent**
- Runtime: `copilot`
- Model: `claude-sonnet-4.5`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25774200725)

## Experiment Config
| Parameter | Value |
|-----------|-------|
| Model | `claude-sonnet-4.5` |
| Agent config | `ai4curation/go-ontology-agent-config@v9:.` |
| Iteration | `1` |
| URL prefix | `https://href.li/?` |
| Base branch | `eval-base-issue-31670` |

See workflow artifacts for full agent trace.