### PR TITLE
[DO NOT MERGE] eval #31670 i:1: Taxon constraint: please add for GO:0070478 and similar terms (claude/sonnet-4.5, .)

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -1,11 +1,7 @@
 defined_class	defined_class_label	taxon	taxon_label	source
-GO:0014019	neuroblast development	NCBITaxon:33213	Bilateria	
-GO:0001772	immunological synapse	NCBITaxon:7742	Vertebrata	
-GO:0031911	cytoproct	NCBITaxon:5878	Ciliophora	
-GO:0008088	axo-dendritic transport	NCBITaxon:33208	Metazoa	
-GO:0099563	modification of synaptic structure	NCBITaxon:33208	Metazoa	
 GO:0000132	establishment of mitotic spindle orientation	NCBITaxon:2759	Eukaryota	
 GO:0000165	MAPK cascade	NCBITaxon:2759	Eukaryota	
+GO:0000184	nuclear-transcribed mRNA catabolic process, nonsense-mediated decay	NCBITaxon:2759	Eukaryota	
 GO:0000278	mitotic cell cycle	NCBITaxon:2759	Eukaryota	
 GO:0000282	cellular bud site selection	NCBITaxon:4751	Fungi	
 GO:0000324	fungal-type vacuole	NCBITaxon:4751	Fungi	
@@ -21,8 +17,16 @@ GO:0000748	conjugation with mutual genetic exchange	NCBITaxon:5878	Ciliophora
 GO:0000749	response to pheromone triggering conjugation with cellular fusion	NCBITaxon:4751	Fungi	
 GO:0000751	mitotic cell cycle G1 arrest in response to pheromone	NCBITaxon:4751	Fungi	
 GO:0000755	cytogamy	NCBITaxon:4751	Fungi	
+GO:0000908	taurine dioxygenase activity	NCBITaxon:2	Bacteria	
 GO:0000911	cytokinesis by cell plate formation	NCBITaxon:33090	Viridiplantae	
 GO:0000936	primary cell septum	NCBITaxon:2759	Eukaryota	
+GO:0000956	nuclear-transcribed mRNA catabolic process	NCBITaxon:2759	Eukaryota	
+GO:0000957	mitochondrial RNA catabolic process	NCBITaxon:2759	Eukaryota	
+GO:0000958	mitochondrial mRNA catabolic process	NCBITaxon:2759	Eukaryota	
+GO:0000959	mitochondrial RNA metabolic process	NCBITaxon:2759	Eukaryota	
+GO:0000963	mitochondrial RNA processing	NCBITaxon:2759	Eukaryota	
+GO:0000964	mitochondrial RNA 5'-end processing	NCBITaxon:2759	Eukaryota	
+GO:0000965	mitochondrial RNA 3'-end processing	NCBITaxon:2759	Eukaryota	
 GO:0001070	RNA-binding transcription regulator activity	NCBITaxon:10239	Viruses	
 GO:0001403	invasive growth in response to glucose limitation	NCBITaxon:4751	Fungi	
 GO:0001410	chlamydospore formation	NCBITaxon:4751	Fungi	
@@ -36,44 +40,78 @@ GO:0001700	embryonic development via the syncytial blastoderm	NCBITaxon:50557	In
 GO:0001701	in utero embryonic development	NCBITaxon:32525	Theria <Mammalia>	
 GO:0001702	gastrulation with mouth forming second	NCBITaxon:33511	Deuterostomia	
 GO:0001703	gastrulation with mouth forming first	NCBITaxon:33317	Protostomia	
+GO:0001734	mRNA (N6-adenosine)-methyltransferase activity	NCBITaxon:2759	Eukaryota	
 GO:0001740	Barr body	NCBITaxon:40674	Mammalia	
 GO:0001745	compound eye morphogenesis	NCBITaxon:6656	Arthropoda	
 GO:0001748	optic lobe placode development	NCBITaxon:6656	Arthropoda	
+GO:0001772	immunological synapse	NCBITaxon:7742	Vertebrata	
+GO:0001775	cell activation	NCBITaxon:33208	Metazoa	
+GO:0001776	leukocyte homeostasis	NCBITaxon:7742	Vertebrata <Metazoa>	
 GO:0001824	blastocyst development	NCBITaxon:32525	Theria <Mammalia>	
 GO:0001890	placenta development	NCBITaxon:32525	Theria <Mammalia>	
+GO:0001909	leukocyte mediated cytotoxicity	NCBITaxon:7742	Vertebrata <Metazoa>	
 GO:0001967	suckling behavior	NCBITaxon:40674	Mammalia	
 GO:0002119	nematode larval development	NCBITaxon:33213	Bilateria	
 GO:0002165	instar larval or pupal development	NCBITaxon:6656	Arthropoda	
+GO:0002227	innate immune response in mucosa	NCBITaxon:7711	Chordata	
 GO:0002250	adaptive immune response	NCBITaxon:33208	Metazoa	
+GO:0002384	hepatic immune response	NCBITaxon:7742	Vertebrata <Metazoa>	
+GO:0002388	immune response in Peyer's patch	NCBITaxon:32524	Amniota	
+GO:0002389	tolerance induction in Peyer's patch	NCBITaxon:32524	Amniota	
 GO:0002414	immunoglobulin transcytosis in epithelial cells	NCBITaxon:33208	Metazoa	
+GO:0002443	leukocyte mediated immunity	NCBITaxon:7742	Vertebrata <Metazoa>	
+GO:0002499	proteolysis within endosome associated with antigen processing and presentation	NCBITaxon:2759	Eukaryota	
 GO:0002822	regulation of adaptive immune response based on somatic recombination of immune receptors built from immunoglobulin superfamily domains	NCBITaxon:7776	Gnathostomata <vertebrate>	
 GO:0003341	cilium movement	NCBITaxon:2759	Eukaryota	
+GO:0004159	dihydropyrimidine dehydrogenase (NAD+) activity	NCBITaxon:2	Bacteria	
+GO:0004164	diphthine synthase activity	NCBITaxon:2157	Archaea	PMID:24739148
 GO:0004694	eukaryotic translation initiation factor 2alpha kinase activity	NCBITaxon:2759	Eukaryota	
+GO:0005009	insulin-activated receptor activity	NCBITaxon:6072	Eumetazoa	
 GO:0005183	gonadotropin hormone-releasing hormone activity	NCBITaxon:33208	Metazoa	
 GO:0005212	structural constituent of eye lens	NCBITaxon:6072	Eumetazoa	
 GO:0005214	structural constituent of chitin-based cuticle	NCBITaxon:6656	Arthropoda	
+GO:0005214	structural constituent of chitin-based cuticle	NCBITaxon:6656	Arthropoda	
+GO:0005326	neurotransmitter transmembrane transporter activity	NCBITaxon:6072	Eumetazoa	
 GO:0005521	lamin binding	NCBITaxon:33208	Metazoa	
 GO:0005581	collagen trimer	NCBITaxon:33208	Metazoa	PMID:12382326
 GO:0005628	prospore membrane	NCBITaxon:4890	Ascomycota	
+GO:0005634	nucleus	NCBITaxon:2759	Eukaryota	
+GO:0005739	mitochondrion	NCBITaxon:2759	Eukaryota	
 GO:0005768	endosome	NCBITaxon:2759	Eukaryota	
+GO:0005773	vacuole	NCBITaxon:2759	Eukaryota	
+GO:0005783	endoplasmic reticulum	NCBITaxon:2759	Eukaryota	
 GO:0005786	signal recognition particle, endoplasmic reticulum targeting	NCBITaxon:2759	Eukaryota	
+GO:0005793	endoplasmic reticulum-Golgi intermediate compartment	NCBITaxon:2759	Eukaryota	
+GO:0005794	Golgi apparatus	NCBITaxon:2759	Eukaryota	
+GO:0005801	cis-Golgi network	NCBITaxon:2759	Eukaryota	
 GO:0005816	spindle pole body	NCBITaxon:4751	Fungi	
 GO:0005826	actomyosin contractile ring	NCBITaxon:2759	Eukaryota	
 GO:0005850	eukaryotic translation initiation factor 2 complex	NCBITaxon:2759	Eukaryota	
 GO:0005851	eukaryotic translation initiation factor 2B complex	NCBITaxon:2759	Eukaryota	
 GO:0005852	eukaryotic translation initiation factor 3 complex	NCBITaxon:2759	Eukaryota	
 GO:0005853	eukaryotic translation elongation factor 1 complex	NCBITaxon:2759	Eukaryota	
+GO:0005883 	neurofilament	NCBITaxon:6072	Eumetazoa	
+GO:0005899	insulin receptor complex	NCBITaxon:6072	Eumetazoa	
 GO:0005917	nephrocyte diaphragm	NCBITaxon:50557	Insecta	
 GO:0005918	septate junction	NCBITaxon:6656	Arthropoda	
 GO:0005921	gap junction	NCBITaxon:6072	Eumetazoa	
 GO:0005929	cilium	NCBITaxon:2759	Eukaryota	
+GO:0006264	mitochondrial DNA replication	NCBITaxon:2759	Eukaryota	
+GO:0006390	mitochondrial transcription	NCBITaxon:2759	Eukaryota	
+GO:0006393	termination of mitochondrial transcription	NCBITaxon:2759	Eukaryota	
+GO:0006693	prostaglandin metabolic process	NCBITaxon:6072	Eumetazoa	
+GO:0006699	bile acid biosynthetic process	NCBITaxon:6072	Eumetazoa	
+GO:0006836	neurotransmitter transport	NCBITaxon:33208	Metazoa	
 GO:0006914	autophagy	NCBITaxon:2759	Eukaryota	
 GO:0006915	apoptotic process	NCBITaxon:33154	Opisthokonta	
 GO:0006954	inflammatory response	NCBITaxon:7742	Vertebrata <Metazoa>	
+GO:0007006	mitochondrial membrane organization	NCBITaxon:2759	Eukaryota	
 GO:0007052	mitotic spindle organization	NCBITaxon:2759	Eukaryota	
 GO:0007053	spindle assembly involved in male meiosis	NCBITaxon:2759	Eukaryota	
 GO:0007056	spindle assembly involved in female meiosis	NCBITaxon:2759	Eukaryota	
 GO:0007159	leukocyte cell-cell adhesion	NCBITaxon:33208	Metazoa	
+GO:0007159	leukocyte cell-cell adhesion	NCBITaxon:7742	Vertebrata <Metazoa>	
+GO:0007179	transforming growth factor beta receptor signaling pathway	NCBITaxon:33511	Deuterostomia	
 GO:0007282	cystoblast division	NCBITaxon:6656	Arthropoda	
 GO:0007293	germarium-derived egg chamber formation	NCBITaxon:6656	Arthropoda	
 GO:0007294	germarium-derived oocyte fate determination	NCBITaxon:50557	Insecta	
@@ -101,23 +139,32 @@ GO:0007484	imaginal disc-derived genitalia development	NCBITaxon:6656	Arthropoda
 GO:0007486	imaginal disc-derived female genitalia development	NCBITaxon:33392	Holometabola	
 GO:0007503	fat body development	NCBITaxon:6656	Arthropoda	
 GO:0007516	hemocyte development	NCBITaxon:6656	Arthropoda	
+GO:0007533	mating type switching	NCBITaxon:4751	Fungi	
 GO:0007565	female pregnancy	NCBITaxon:40674	Mammalia	
 GO:0007591	molting cycle, chitin-based cuticle	NCBITaxon:6656	Arthropoda	
 GO:0007594	puparial adhesion	NCBITaxon:7147	Diptera	
 GO:0007595	lactation	NCBITaxon:40674	Mammalia	
 GO:0007610	behavior	NCBITaxon:33208	Metazoa	
 GO:0008069	dorsal/ventral axis specification, ovarian follicular epithelium	NCBITaxon:50557	Insecta	
+GO:0008088	axo-dendritic transport	NCBITaxon:33208	Metazoa	
+GO:0008147	structural constituent of bone	NCBITaxon:7742	Vertebrata <Metazoa>	
 GO:0008190	eukaryotic initiation factor 4E binding	NCBITaxon:2759	Eukaryota	
+GO:0008286	insulin receptor signaling pathway	NCBITaxon:6072	Eumetazoa	
 GO:0008302	female germline ring canal formation, actin assembly	NCBITaxon:50557	Insecta	
+GO:0008316	structural constituent of vitelline membrane	NCBITaxon:33213	Bilateria	
 GO:0008316	structural constituent of vitelline membrane	NCBITaxon:6656	Arthropoda	
 GO:0008347	glial cell migration	NCBITaxon:33208	Metazoa	
 GO:0008364	pupal chitin-based cuticle development	NCBITaxon:50557	Insecta	
 GO:0008583	mystery cell differentiation	NCBITaxon:33392	Holometabola	
+GO:0008815	citrate (pro-3S)-lyase activity	NCBITaxon:2	Bacteria	
 GO:0008917	lipopolysaccharide N-acetylglucosaminyltransferase activity	NCBITaxon:2	Bacteria	
 GO:0008918	lipopolysaccharide 3-alpha-galactosyltransferase activity	NCBITaxon:2	Bacteria	
 GO:0008919	lipopolysaccharide glucosyltransferase I activity	NCBITaxon:2	Bacteria	
+GO:0009048	dosage compensation by inactivation of X chromosome	NCBITaxon:32524	Amniota	PMID:19802707
 GO:0009103	lipopolysaccharide biosynthetic process	NCBITaxon:2	Bacteria	
+GO:0009236	cobalamin biosynthetic process	NCBITaxon:Union_0000004	Prokaryota	
 GO:0009252	peptidoglycan biosynthetic process	NCBITaxon:2	Bacteria	
+GO:0009271	phage shock	NCBITaxon:2	Bacteria	
 GO:0009272	fungal-type cell wall biogenesis	NCBITaxon:4751	Fungi	
 GO:0009273	peptidoglycan-based cell wall biogenesis	NCBITaxon:2	Bacteria	
 GO:0009274	peptidoglycan-based cell wall	NCBITaxon:2	Bacteria	
@@ -125,15 +172,22 @@ GO:0009275	Gram-positive-bacterium-type cell wall	NCBITaxon:2	Bacteria
 GO:0009276	Gram-negative-bacterium-type cell wall	NCBITaxon:2	Bacteria	
 GO:0009277	fungal-type cell wall	NCBITaxon:4751	Fungi	
 GO:0009288	bacterial-type flagellum	NCBITaxon:2	Bacteria	
+GO:0009289	pilus	NCBITaxon:2	Bacteria	
 GO:0009291	unidirectional conjugation	NCBITaxon:Union_0000004	Prokaryota	
+GO:0009331	glycerol-3-phosphate dehydrogenase complex	NCBITaxon:Union_0000004	Prokaryota	
+GO:0009346	ATP-independent citrate lyase complex	NCBITaxon:2	Bacteria	
+GO:0009359	type II site-specific deoxyribonuclease complex	NCBITaxon:Union_0000004	Prokaryota	
 GO:0009399	nitrogen fixation	NCBITaxon:Union_0000004	Prokaryota	
+GO:0009486	cytochrome bo3 ubiquinol oxidase activity	NCBITaxon:2	Bacteria	
 GO:0009501	amyloplast	NCBITaxon:33090	Viridiplantae	
 GO:0009503	thylakoid light-harvesting complex	NCBITaxon:33090	Viridiplantae	
+GO:0009504	cell plate	NCBITaxon:33090	Viridiplantae	
 GO:0009505	plant-type cell wall	NCBITaxon:33090	Viridiplantae	
 GO:0009509	chromoplast	NCBITaxon:33090	Viridiplantae	
 GO:0009513	etioplast	NCBITaxon:33090	Viridiplantae	
 GO:0009515	granal stacked thylakoid	NCBITaxon:33090	Viridiplantae	
 GO:0009516	leucoplast	NCBITaxon:33090	Viridiplantae	
+GO:0009524	phragmoplast	NCBITaxon:33090	Viridiplantae	
 GO:0009533	chloroplast stromal thylakoid	NCBITaxon:33090	Viridiplantae	
 GO:0009541	etioplast prolamellar body	NCBITaxon:33090	Viridiplantae	
 GO:0009542	granum	NCBITaxon:33090	Viridiplantae	
@@ -173,6 +227,9 @@ GO:0009853	photorespiration	NCBITaxon:Union_0000007	Viridiplantae or Bacteria or
 GO:0009856	pollination	NCBITaxon:33090	Viridiplantae	
 GO:0009864	induced systemic resistance, jasmonic acid mediated signaling pathway	NCBITaxon:33090	Viridiplantae	
 GO:0009866	induced systemic resistance, ethylene mediated signaling pathway	NCBITaxon:33090	Viridiplantae	
+GO:0009877	nodulation	NCBITaxon:33090	Viridiplantae	
+GO:0009887	animal organ morphogenesis	NCBITaxon:6072	Eumetazoa	
+GO:0009887	animal organ morphogenesis	NCBITaxon:6072	Eumetazoa	
 GO:0009888	tissue development	NCBITaxon:2759	Eukaryota	
 GO:0009908	flower development	NCBITaxon:3398	Magnoliophyta	
 GO:0009920	cell plate formation involved in plant-type cell wall biogenesis	NCBITaxon:33090	Viridiplantae	
@@ -192,9 +249,11 @@ GO:0010091	trichome branching	NCBITaxon:33090	Viridiplantae
 GO:0010099	regulation of photomorphogenesis	NCBITaxon:33090	Viridiplantae	
 GO:0010152	pollen maturation	NCBITaxon:3398	Magnoliophyta	
 GO:0010154	fruit development	NCBITaxon:58024	Spermatophyta	
+GO:0010168	ER body	NCBITaxon:2759	Eukaryota	
 GO:0010197	polar nucleus fusion	NCBITaxon:3398	Magnoliophyta	
 GO:0010208	pollen wall assembly	NCBITaxon:3398	Magnoliophyta	
 GO:0010214	seed coat development	NCBITaxon:33090	Viridiplantae	
+GO:0010236	plastoquinone biosynthetic process	NCBITaxon:33090	Viridiplantae	
 GO:0010242	oxygen evolving activity	NCBITaxon:Union_0000007	Viridiplantae or Bacteria or Euglenozoa	
 GO:0010278	chloroplast outer membrane translocon	NCBITaxon:33090	Viridiplantae	
 GO:0010287	plastoglobule	NCBITaxon:33090	Viridiplantae	
@@ -207,48 +266,75 @@ GO:0010374	stomatal complex development	NCBITaxon:33090	Viridiplantae
 GO:0010377	guard cell fate commitment	NCBITaxon:33090	Viridiplantae	
 GO:0010433	bract morphogenesis	NCBITaxon:33090	Viridiplantae	
 GO:0010434	bract formation	NCBITaxon:33090	Viridiplantae	
+GO:0010597	green leaf volatile biosynthetic process	NCBITaxon:33090	Viridiplantae	
 GO:0010657	muscle cell apoptotic process	NCBITaxon:33208	Metazoa	
+GO:0010736	serum response element binding	NCBITaxon:6072	Eumetazoa	
 GO:0010865	stipule development	NCBITaxon:33090	Viridiplantae	
 GO:0012511	monolayer-surrounded lipid storage body	NCBITaxon:33090	Viridiplantae	
+GO:0014019	neuroblast development	NCBITaxon:33213	Bilateria	
 GO:0014021	secondary neural tube formation	NCBITaxon:40674	Mammalia	
 GO:0014023	neural rod formation	NCBITaxon:32443	Teleostei	
+GO:0014714	myoblast fate commitment in head	NCBITaxon:33213	Bilateria	
 GO:0015627	type II protein secretion system complex	NCBITaxon:2	Bacteria	
 GO:0015628	protein secretion by the type II secretion system	NCBITaxon:2	Bacteria	
+GO:0016007	mitochondrial derivative	NCBITaxon:2759	Eukaryota	
 GO:0016028	rhabdomere	NCBITaxon:50557	Insecta	PMID:28193819
 GO:0016281	eukaryotic translation initiation factor 4F complex	NCBITaxon:2759	Eukaryota	
 GO:0016282	eukaryotic 43S preinitiation complex	NCBITaxon:2759	Eukaryota	
+GO:0016323	basolateral plasma membrane	NCBITaxon:33208	Metazoa	
 GO:0016348	imaginal disc-derived leg joint morphogenesis	NCBITaxon:33392	Holometabola	
 GO:0016490	structural constituent of peritrophic membrane	NCBITaxon:6656	Arthropoda	
 GO:0016543	male courtship behavior, orientation prior to leg tapping and wing vibration	NCBITaxon:6656	Arthropoda	
 GO:0016544	male courtship behavior, tapping to detect pheromone	NCBITaxon:6656	Arthropoda	
 GO:0016546	male courtship behavior, proboscis-mediated licking	NCBITaxon:6656	Arthropoda	
+GO:0017113	dihydropyrimidine dehydrogenase (NADP+) activity	NCBITaxon:2759	Eukaryota	
+GO:0018189	pyrroloquinoline quinone biosynthetic process	NCBITaxon:2	Bacteria	
+GO:0018679	dibenzothiophene-5,5-dioxide monooxygenase activity	NCBITaxon:Union_0000004	Prokaryota	
 GO:0018990	ecdysis, chitin-based cuticle	NCBITaxon:6656	Arthropoda	
+GO:0019035	viral integration complex	NCBITaxon:10239	Viruses	
+GO:0019093	mitochondrial RNA localization	NCBITaxon:2759	Eukaryota	
 GO:0019096	pole plasm mitochondrial lrRNA localization	NCBITaxon:6656	Arthropoda	
 GO:0019097	pole plasm mitochondrial srRNA localization	NCBITaxon:6656	Arthropoda	
+GO:0019270	aerobactin biosynthetic process	NCBITaxon:Union_0000004	Prokaryota	
 GO:0019350	teichoic acid biosynthetic process	NCBITaxon:2	Bacteria	
+GO:0019658	bifid shunt	NCBITaxon:2	Bacteria	
+GO:0019725	cellular homeostasis	NCBITaxon:131567	cellular organisms	
+GO:0019812	type I site-specific deoxyribonuclease complex	NCBITaxon:Union_0000004	Prokaryota	
+GO:0019813	type III site-specific deoxyribonuclease complex	NCBITaxon:Union_0000004	Prokaryota	
 GO:0019819	P1 peroxisome	NCBITaxon:4952	Yarrowia lipolytica	PMID:10629216|PMID:14504266
 GO:0019820	P2 peroxisome	NCBITaxon:4952	Yarrowia lipolytica	PMID:10629216|PMID:14504266
 GO:0019821	P3 peroxisome	NCBITaxon:4952	Yarrowia lipolytica	PMID:10629216|PMID:14504266
 GO:0019822	P4 peroxisome	NCBITaxon:4952	Yarrowia lipolytica	PMID:10629216|PMID:14504266
 GO:0019823	P5 peroxisome	NCBITaxon:4952	Yarrowia lipolytica	PMID:10629216|PMID:14504266
 GO:0019824	P6 peroxisome	NCBITaxon:4952	Yarrowia lipolytica	PMID:10629216|PMID:14504266
+GO:0019833	ice nucleation activity	NCBITaxon:2	Bacteria	
+GO:0019905	syntaxin binding	NCBITaxon:2	Bacteria	
+GO:0019911	structural constituent of myelin sheath	NCBITaxon:33208	Metazoa	
 GO:0020007	apical complex	NCBITaxon:5794	Apicomplexa	
+GO:0020009	microneme	NCBITaxon:2759	Eukaryota	
 GO:0020011	apicoplast	NCBITaxon:5794	Apicomplexa	PMID:12722949
 GO:0020015	glycosome	NCBITaxon:2759	Eukaryota	
 GO:0020020	food vacuole	NCBITaxon:5794	Apicomplexa	
+GO:0020023	kinetoplast	NCBITaxon:5653	Kinetoplastea	
 GO:0020026	merozoite dense granule	NCBITaxon:5794	Apicomplexa	
 GO:0020030	infected host cell surface knob	NCBITaxon:5820	Plasmodium	
 GO:0020038	subpellicular network	NCBITaxon:33682	Euglenozoa	
+GO:0021533	cell differentiation in hindbrain	NCBITaxon:89593	Craniata <chordata>	
+GO:0021534	cell proliferation in hindbrain	NCBITaxon:89593	Craniata <chordata>	
+GO:0021535	cell migration in hindbrain	NCBITaxon:89593	Craniata <chordata>	
 GO:0021724	inferior raphe nucleus development	NCBITaxon:7742	Vertebrata <Metazoa>	
 GO:0021725	superior raphe nucleus development	NCBITaxon:7742	Vertebrata <Metazoa>	
+GO:0022010	central nervous system myelination	NCBITaxon:33213	Bilateria	
 GO:0022416	chaeta development	NCBITaxon:50557	Insecta	
 GO:0022602	ovulation cycle process	NCBITaxon:33208	Metazoa	
 GO:0022619	generative cell differentiation	NCBITaxon:3398	Magnoliophyta	
+GO:0022620	microgametophyte vegetative cell differentiation	NCBITaxon:58024	Spermatophyta	
 GO:0022620	vegetative cell differentiation	NCBITaxon:3398	Magnoliophyta	
 GO:0022625	cytosolic large ribosomal subunit	NCBITaxon:131567	cellular organisms	
 GO:0022626	cytosolic ribosome	NCBITaxon:131567	cellular organisms	
 GO:0022627	cytosolic small ribosomal subunit	NCBITaxon:131567	cellular organisms	
 GO:0022809	mobile ion carrier activity	NCBITaxon:2	Bacteria	
+GO:0030034	microvillar actin bundle assembly	NCBITaxon:33208	Metazoa	
 GO:0030073	insulin secretion	NCBITaxon:6072	Eumetazoa	
 GO:0030075	bacterial thylakoid	NCBITaxon:2	Bacteria	
 GO:0030077	plasma membrane light-harvesting complex	NCBITaxon:Union_0000004	Prokaryota	
@@ -257,10 +343,13 @@ GO:0030081	B800-820 antenna complex	NCBITaxon:Union_0000004	Prokaryota
 GO:0030082	B800-850 antenna complex	NCBITaxon:Union_0000004	Prokaryota	
 GO:0030085	PSII associated light-harvesting complex II, peripheral complex, LHCIIb subcomplex	NCBITaxon:33090	Viridiplantae	
 GO:0030093	chloroplast photosystem I	NCBITaxon:33090	Viridiplantae	
+GO:0030097	hemopoiesis	NCBITaxon:6072	Eumetazoa	
 GO:0030256	type I protein secretion system complex	NCBITaxon:2	Bacteria	
 GO:0030257	type III protein secretion system complex	NCBITaxon:2	Bacteria	
 GO:0030313	cell envelope	NCBITaxon:2	Bacteria	
+GO:0030386	ferredoxin:thioredoxin reductase complex	NCBITaxon_Union:0000002	Viridiplantae or Cyanobacteria	
 GO:0030427	site of polarized growth	NCBITaxon:131567	cellular organisms	
+GO:0030428	cell septum	NCBITaxon:Union_0000020	Fungi or Bacteria	
 GO:0030437	ascospore formation	NCBITaxon:4890	Ascomycota	
 GO:0030479	actin cortical patch	NCBITaxon:4751	Fungi	
 GO:0030537	larval behavior	NCBITaxon:6072	Eumetazoa	
@@ -268,6 +357,7 @@ GO:0030584	sporocarp development	NCBITaxon:4751	Fungi
 GO:0030587	sorocarp development	NCBITaxon:33083	Dictyostelids	
 GO:0030588	pseudocleavage	NCBITaxon:33208	Metazoa	
 GO:0030590	first cell cycle pseudocleavage	NCBITaxon:33213	Bilateria	
+GO:0030594	neurotransmitter receptor activity	NCBITaxon:33208	Metazoa	
 GO:0030680	dimeric ribonuclease P complex	NCBITaxon:2	Bacteria	
 GO:0030703	eggshell formation	NCBITaxon:33208	Metazoa	
 GO:0030707	ovarian follicle cell development	NCBITaxon:6656	Arthropoda	
@@ -278,36 +368,75 @@ GO:0030723	ovarian fusome organization	NCBITaxon:50557	Insecta
 GO:0030879	mammary gland development	NCBITaxon:40674	Mammalia	
 GO:0030930	homotetrameric ADPG pyrophosphorylase complex	NCBITaxon:2	Bacteria	
 GO:0030931	heterotetrameric ADPG pyrophosphorylase complex	NCBITaxon:2759	Eukaryota	
+GO:0030941	chloroplast targeting sequence binding	NCBITaxon:33090	Viridiplantae	
+GO:0031039	macronucleus	NCBITaxon:5878	Ciliophora	
+GO:0031040	micronucleus	NCBITaxon:5878	Ciliophora	
+GO:0031094	platelet dense tubular network	NCBITaxon:2759	Eukaryota	
+GO:0031299	taurine-pyruvate aminotransferase activity	NCBITaxon:2	Bacteria	PMID:11082195
 GO:0031321	ascospore-type prospore assembly	NCBITaxon:4890	Ascomycota	
 GO:0031370	eukaryotic initiation factor 4G binding	NCBITaxon:2759	Eukaryota	
+GO:0031436	BRCA1-BARD1 complex	NCBITaxon:6072	Eumetazoa	
+GO:0031469	bacterial microcompartment	NCBITaxon:2	Bacteria	
 GO:0031504	peptidoglycan-based cell wall organization	NCBITaxon:2	Bacteria	
 GO:0031505	fungal-type cell wall organization	NCBITaxon:4751	Fungi	
 GO:0031522	cell envelope Sec protein transport complex	NCBITaxon:2	Bacteria	
 GO:0031578	mitotic spindle orientation checkpoint	NCBITaxon:716545	saccharomyceta	
 GO:0031633	xanthophore	NCBITaxon:Union_0000004	Prokaryota	
+GO:0031639	plasminogen activation	NCBITaxon:7742	Vertebrata <Metazoa>	
+GO:0031643	positive regulation of myelination	NCBITaxon:6072	Eumetazoa	
 GO:0031897	Tic complex	NCBITaxon:33090	Viridiplantae	
+GO:0031911	cytoproct	NCBITaxon:5878	Ciliophora	
 GO:0031912	oral apparatus	NCBITaxon:5878	Ciliophora	
 GO:0031986	proteinoplast	NCBITaxon:33090	Viridiplantae	
+GO:0032042	mitochondrial DNA metabolic process	NCBITaxon:2759	Eukaryota	
+GO:0032043	mitochondrial DNA catabolic process	NCBITaxon:2759	Eukaryota	
+GO:0032047	mitosome	NCBITaxon:2759	Eukaryota	
+GO:0032068	type IV site-specific deoxyribonuclease complex	NCBITaxon:Union_0000004	Prokaryota	
 GO:0032121	meiotic attachment of telomeric heterochromatin to spindle pole body	NCBITaxon:4751	Fungi	
+GO:0032186	cellular bud neck septin ring organization	NCBITaxon:147537	Saccharomycotina	
 GO:0032258	protein localization by the Cvt pathway	NCBITaxon:147537	Saccharomycotina	
+GO:0032286	central nervous system myelin maintenance	NCBITaxon:33213	Bilateria	
+GO:0032289	central nervous system myelin formation	NCBITaxon:33213	Bilateria	
+GO:0032291	axon ensheathment in central nervous system	NCBITaxon:33213	Bilateria	
+GO:0032293	non-myelinated axon ensheathment in central nervous system	NCBITaxon:33213	Bilateria	
+GO:0032468	Golgi calcium ion homeostasis	NCBITaxon:2759	Eukaryota	
+GO:0032469	endoplasmic reticulum calcium ion homeostasis	NCBITaxon:2759	Eukaryota	
+GO:0032507	maintenance of protein location in cell	NCBITaxon:131567	cellular organisms	
+GO:0032543	mitochondrial translation	NCBITaxon:2759	Eukaryota	
+GO:0032727	positive regulation of interferon-alpha production	NCBITaxon:6072	Eumetazoa	
+GO:0032729	positive regulation of type II interferon production	NCBITaxon:6072	Eumetazoa	
+GO:0032755	positive regulation of interleukin-6 production	NCBITaxon:6072	Eumetazoa	
+GO:0033009	nucleomorph	NCBITaxon:33090	Viridiplantae	
+GO:0033012	porosome	NCBITaxon:6072	Eumetazoa	
 GO:0033104	type VI protein secretion system complex	NCBITaxon:2	Bacteria	
 GO:0033105	chlorosome envelope	NCBITaxon:Union_0000004	Prokaryota	
 GO:0033173	calcineurin-NFAT signaling cascade	NCBITaxon:33208	Metazoa	
 GO:0033189	response to vitamin A	NCBITaxon:33208	Metazoa	
+GO:0033260	nuclear DNA replication	NCBITaxon:2759	Eukaryota	
+GO:0033260	nuclear DNA replication	NCBITaxon:2759	Eukaryota	
 GO:0033290	eukaryotic 48S preinitiation complex	NCBITaxon:2759	Eukaryota	
 GO:0033291	eukaryotic 80S initiation complex	NCBITaxon:2759	Eukaryota	
 GO:0033614	chloroplast proton-transporting ATP synthase complex assembly	NCBITaxon:33090	Viridiplantae	
+GO:0033615	mitochondrial proton-transporting ATP synthase complex assembly	NCBITaxon:2759	Eukaryota	
+GO:0033617	mitochondrial respiratory chain complex IV assembly	NCBITaxon:2759	Eukaryota	
+GO:0033693	neurofilament bundle assembly	NCBITaxon:33208	Metazoa	
 GO:0034117	erythrocyte aggregation	NCBITaxon:33208	Metazoa	
 GO:0034306	regulation of sexual sporulation	NCBITaxon:4751	Fungi	
+GO:0034354	'de novo' NAD biosynthetic process from tryptophan	NCBITaxon:2759	Eukaryota	
 GO:0034400	gerontoplast	NCBITaxon:33090	Viridiplantae	
+GO:0034551	mitochondrial respiratory chain complex III assembly	NCBITaxon:2759	Eukaryota	
+GO:0034553	mitochondrial respiratory chain complex II assembly	NCBITaxon:2759	Eukaryota	
+GO:0034587	piRNA processing	NCBITaxon:6072	Eumetazoa	
 GO:0034631	microtubule anchoring at spindle pole body	NCBITaxon:4751	Fungi	
 GO:0034633	retinol transport	NCBITaxon:33208	Metazoa	
+GO:0034982	mitochondrial protein processing	NCBITaxon:2759	Eukaryota	
 GO:0035001	dorsal trunk growth, open tracheal system	NCBITaxon:50557	Insecta	
 GO:0035002	liquid clearance, open tracheal system	NCBITaxon:50557	Insecta	
 GO:0035018	adult chitin-based cuticle pattern formation	NCBITaxon:6656	Arthropoda	
 GO:0035052	dorsal vessel aortic cell fate commitment	NCBITaxon:50557	Insecta	
 GO:0035053	dorsal vessel heart proper cell fate commitment	NCBITaxon:50557	Insecta	
 GO:0035099	hemocyte migration	NCBITaxon:6656	Arthropoda	
+GO:0035145	exon-exon junction complex	NCBITaxon:2759	Eukaryota	
 GO:0035147	branch fusion, open tracheal system	NCBITaxon:33317	Protostomia	
 GO:0035152	regulation of tube architecture, open tracheal system	NCBITaxon:33317	Protostomia	
 GO:0035153	epithelial cell type specification, open tracheal system	NCBITaxon:50557	Insecta	
@@ -317,16 +446,23 @@ GO:0035158	regulation of tube diameter, open tracheal system	NCBITaxon:33317	Pro
 GO:0035159	regulation of tube length, open tracheal system	NCBITaxon:33317	Protostomia	
 GO:0035172	hemocyte proliferation	NCBITaxon:6656	Arthropoda	
 GO:0035207	negative regulation of hemocyte proliferation	NCBITaxon:6656	Arthropoda	
+GO:0035244	peptidyl-arginine C-methyltransferase activity	NCBITaxon:2	Bacteria	
 GO:0035277	spiracle morphogenesis, open tracheal system	NCBITaxon:33317	Protostomia	
 GO:0035316	non-sensory hair organization	NCBITaxon:6656	Arthropoda	
+GO:0035437	maintenance of protein localization in endoplasmic reticulum	NCBITaxon:2759	Eukaryota	
 GO:0035633	maintenance of permeability of blood-brain barrier	NCBITaxon:6072	Eumetazoa	
 GO:0035670	plant-type ovary development	NCBITaxon:3398	Magnoliophyta	
+GO:0035694	mitochondrial protein catabolic process	NCBITaxon:2759	Eukaryota	
+GO:0035804	structural constituent of egg coat	NCBITaxon:33208	Metazoa	
 GO:0035804	structural constituent of egg coat	NCBITaxon:33208	Metazoa	
 GO:0035805	egg coat	NCBITaxon:33208	Metazoa	
 GO:0036007	scintillon	NCBITaxon:2864	Dinophyceae	
 GO:0036342	post-anal tail morphogenesis	NCBITaxon:7711	Chordata	
 GO:0036386	bacterial nucleoid DNA packaging	NCBITaxon:2	Bacteria	
+GO:0036386	bacterial nucleoid DNA packaging	NCBITaxon:2	Bacteria	
 GO:0036389	bacterial pre-replicative complex	NCBITaxon:2	Bacteria	
+GO:0036411	H-NS-Cnu complex	NCBITaxon:2	Bacteria	
+GO:0036457	keratohyalin granule	NCBITaxon:6072	Eumetazoa	
 GO:0038084	vascular endothelial growth factor signaling pathway	NCBITaxon:7742	Vertebrata <Metazoa>	
 GO:0038086	VEGF-activated platelet-derived growth factor receptor signaling pathway	NCBITaxon:7742	Vertebrata <Metazoa>	
 GO:0038089	positive regulation of cell migration by vascular endothelial growth factor signaling pathway	NCBITaxon:7742	Vertebrata <Metazoa>	
@@ -336,16 +472,24 @@ GO:0040003	chitin-based cuticle development	NCBITaxon:6656	Arthropoda
 GO:0040007	growth	NCBITaxon:131567	cellular organisms	
 GO:0040021	hermaphrodite germ-line sex determination	NCBITaxon:6231	Nematoda	
 GO:0040025	vulval development	NCBITaxon:6231	Nematoda	
+GO:0040033	sRNA-mediated gene silencing	NCBITaxon:2	Bacteria	
 GO:0042001	hermaphrodite somatic sex determination	NCBITaxon:33213	Bilateria	
+GO:0042073	intraciliary transport	NCBITaxon:2759	Eukaryota	
 GO:0042151	nematocyst	NCBITaxon:33208	Metazoa	
 GO:0042243	asexual spore wall assembly	NCBITaxon:Union_0000020	Fungi or Bacteria	
+GO:0042302	structural constituent of cuticle	NCBITaxon:6072	Eumetazoa	
 GO:0042314	bacteriochlorophyll binding	NCBITaxon:Union_0000004	Prokaryota	
 GO:0042329	structural constituent of collagen and cuticulin-based cuticle	NCBITaxon:6231	Nematoda	
+GO:0042329	structural constituent of collagen and cuticulin-based cuticle	NCBITaxon:6231	Nematoda	
 GO:0042386	hemocyte differentiation	NCBITaxon:6656	Arthropoda	
+GO:0042412	taurine biosynthetic process	NCBITaxon:33208	Metazoa	
 GO:0042463	ocellus photoreceptor cell development	NCBITaxon:6656	Arthropoda	
 GO:0042470	melanosome	NCBITaxon:33208	Metazoa	
 GO:0042475	odontogenesis of dentin-containing tooth	NCBITaxon:7711	Chordata	
+GO:0042541	hemoglobin biosynthetic process	NCBITaxon:6072	Eumetazoa	
 GO:0042556	eukaryotic elongation factor-2 kinase regulator activity	NCBITaxon:2759	Eukaryota	
+GO:0042579	microbody	NCBITaxon:2759	Eukaryota	
+GO:0042597	periplasmic space	NCBITaxon:Union_0000023	Fungi or Bacteria or Archaea	PMID:15803654
 GO:0042601	endospore-forming forespore	NCBITaxon:2	Bacteria	
 GO:0042603	capsule	NCBITaxon:Union_0000020	Fungi or Bacteria	
 GO:0042633	hair cycle	NCBITaxon:40674	Mammalia	
@@ -354,22 +498,39 @@ GO:0042650	prothylakoid membrane	NCBITaxon:33090	Viridiplantae
 GO:0042697	menopause	NCBITaxon:40674	Mammalia	
 GO:0042698	ovulation cycle	NCBITaxon:2759	Eukaryota	
 GO:0042716	plasma membrane-derived chromatophore	NCBITaxon:2	Bacteria	
+GO:0042735	endosperm protein body	NCBITaxon:2759	Eukaryota	
 GO:0042764	ascospore-type prospore	NCBITaxon:4890	Ascomycota	
+GO:0042775	mitochondrial ATP synthesis coupled electron transport	NCBITaxon:2759	Eukaryota	
+GO:0042776	mitochondrial ATP synthesis coupled proton transport	NCBITaxon:2759	Eukaryota	
 GO:0042777	plasma membrane ATP synthesis coupled proton transport	NCBITaxon:Union_0000004	Prokaryota	
 GO:0043009	chordate embryonic development	NCBITaxon:7711	Chordata	
 GO:0043036	starch grain	NCBITaxon:33090	Viridiplantae	
 GO:0043082	megagametophyte egg cell nucleus	NCBITaxon:33090	Viridiplantae	
+GO:0043123	positive regulation of canonical NF-kappaB signal transduction	NCBITaxon:6072	Eumetazoa	
 GO:0043164	Gram-negative-bacterium-type cell wall biogenesis	NCBITaxon:2	Bacteria	
 GO:0043165	Gram-negative-bacterium-type cell outer membrane assembly	NCBITaxon:2	Bacteria	
 GO:0043190	ATP-binding cassette (ABC) transporter complex	NCBITaxon:131567	cellular organisms	
 GO:0043209	myelin sheath	NCBITaxon:33208	Metazoa	
+GO:0043292	contractile muscle fiber	NCBITaxon:6072	Eumetazoa	
+GO:0043299	leukocyte degranulation	NCBITaxon:7742	Vertebrata <Metazoa>	
+GO:0043386	mycotoxin biosynthetic process	NCBITaxon:4751	Fungi	
 GO:0043473	pigmentation	NCBITaxon:131567	cellular organisms	
+GO:0043504	mitochondrial DNA repair	NCBITaxon:2759	Eukaryota	
 GO:0043590	bacterial nucleoid	NCBITaxon:2	Bacteria	
 GO:0043591	endospore external encapsulating structure	NCBITaxon:2	Bacteria	
 GO:0043595	endospore cortex	NCBITaxon:2	Bacteria	
 GO:0043597	cytoplasmic replication fork	NCBITaxon:Union_0000004	Prokaryota	
+GO:0043682	P-type divalent copper transporter activity	NCBITaxon:2	Bacteria	
 GO:0043684	type IV secretion system complex	NCBITaxon:2	Bacteria	
+GO:0043711	pilus organization	NCBITaxon:2	Bacteria	
+GO:0043715	2,3-diketo-5-methylthiopentyl-1-phosphate enolase activity	NCBITaxon:2	Bacteria	
+GO:0043716	2-hydroxy-3-keto-5-methylthiopentenyl-1-phosphate phosphatase activity	NCBITaxon:2	Bacteria	
 GO:0043952	protein transport by the Sec complex	NCBITaxon:2	Bacteria	
+GO:0044105	L-xylulose reductase (NAD+) activity	NCBITaxon:4890	Ascomycota	
+GO:0044222	anammoxosome	NCBITaxon:Union_0000004	Prokaryota	
+GO:0044223	pirellulosome	NCBITaxon:2	Bacteria	
+GO:0044227	methane-oxidizing organelle	NCBITaxon:Union_0000004	Prokaryota	
+GO:0044311	exoneme	NCBITaxon:2759	Eukaryota	
 GO:0044312	crystalloid	NCBITaxon:5794	Apicomplexa	
 GO:0044682	archaeal-specific GTP cyclohydrolase activity	NCBITaxon:2157	Archaea	
 GO:0044770	cell cycle phase transition	NCBITaxon:2759	Eukaryota	
@@ -378,25 +539,37 @@ GO:0044782	cilium organization	NCBITaxon:2759	Eukaryota
 GO:0044787	bacterial-type DNA replication	NCBITaxon:2	Bacteria	
 GO:0044849	estrous cycle	NCBITaxon:32525	Theria <Mammalia>	
 GO:0044850	menstrual cycle	NCBITaxon:9443	Primates	
+GO:0045120	pronucleus	NCBITaxon:33208	Metazoa	
 GO:0045138	nematode male tail tip morphogenesis	NCBITaxon:6231	Nematoda	
 GO:0045152	antisigma factor binding	NCBITaxon:2	Bacteria	
+GO:0045169	fusome	NCBITaxon:6072	Eumetazoa	
 GO:0045170	spectrosome	NCBITaxon:6656	Arthropoda	
 GO:0045172	germline ring canal	NCBITaxon:6656	Arthropoda	
 GO:0045202	synapse	NCBITaxon:33208	Metazoa	
 GO:0045247	cytosolic electron transfer flavoprotein complex	NCBITaxon:Union_0000004	Prokaryota	
 GO:0045249	cytosol pyruvate dehydrogenase (lipoamide) phosphatase complex	NCBITaxon:Union_0000004	Prokaryota	
 GO:0045314	regulation of compound eye photoreceptor development	NCBITaxon:6656	Arthropoda	
+GO:0045321	leukocyte activation	NCBITaxon:7742	Vertebrata <Metazoa>	
 GO:0045498	sex comb development	NCBITaxon:50557	Insecta	
+GO:0045664	regulation of neuron differentiation	NCBITaxon:33208	Metazoa	
 GO:0045688	regulation of antipodal cell differentiation	NCBITaxon:3398	Magnoliophyta	
 GO:0045691	regulation of embryo sac central cell differentiation	NCBITaxon:3398	Magnoliophyta	
 GO:0045694	regulation of embryo sac egg cell differentiation	NCBITaxon:3398	Magnoliophyta	
 GO:0045697	regulation of synergid differentiation	NCBITaxon:3398	Magnoliophyta	
 GO:0046594	maintenance of pole plasm mRNA location	NCBITaxon:33208	Metazoa	
 GO:0046595	establishment of pole plasm mRNA localization	NCBITaxon:6656	Arthropoda	
+GO:0046626	regulation of insulin receptor signaling pathway	NCBITaxon:6072	Eumetazoa	
+GO:0046850	regulation of bone remodeling	NCBITaxon:6072	Eumetazoa	
+GO:0046850	regulation of bone remodeling	NCBITaxon:7742	Vertebrata <Metazoa>	
 GO:0046858	chlorosome	NCBITaxon:Union_0000004	Prokaryota	
+GO:0046868	mesosome	NCBITaxon:2	Bacteria	
+GO:0047077	Photinus-luciferin 4-monooxygenase (ATP-hydrolyzing) activity	NCBITaxon:71193	Elateroidea	
 GO:0047270	lipopolysaccharide glucosyltransferase II activity	NCBITaxon:2	Bacteria	
+GO:0047474	long-chain fatty acid--protein ligase activity	NCBITaxon:2	Bacteria	
+GO:0047522	15-oxoprostaglandin 13-oxidase activity	NCBITaxon:6072	Eumetazoa	
 GO:0048010	vascular endothelial growth factor receptor signaling pathway	NCBITaxon:6072	Eumetazoa	
 GO:0048046	apoplast	NCBITaxon:33090	Viridiplantae	
+GO:0048058	compound eye corneal lens development	NCBITaxon:6656	Arthropoda	
 GO:0048065	male courtship behavior, veined wing extension	NCBITaxon:6656	Arthropoda	
 GO:0048072	compound eye pigmentation	NCBITaxon:6656	Arthropoda	
 GO:0048085	adult chitin-containing cuticle pigmentation	NCBITaxon:6656	Arthropoda	
@@ -411,6 +584,7 @@ GO:0048163	scattered antral spaces stage	NCBITaxon:40674	Mammalia
 GO:0048164	distinct antral spaces stage	NCBITaxon:40674	Mammalia	
 GO:0048165	fused antrum stage	NCBITaxon:40674	Mammalia	
 GO:0048166	mature follicle stage	NCBITaxon:40674	Mammalia	
+GO:0048168	regulation of neuronal synaptic plasticity	NCBITaxon:6072	Eumetazoa	
 GO:0048217	pectic matrix	NCBITaxon:33090	Viridiplantae	
 GO:0048223	hemicellulose network	NCBITaxon:33090	Viridiplantae	
 GO:0048224	lignin network	NCBITaxon:33090	Viridiplantae	
@@ -419,6 +593,7 @@ GO:0048226	Casparian strip	NCBITaxon:33090	Viridiplantae
 GO:0048229	gametophyte development	NCBITaxon:3398	Magnoliophyta	
 GO:0048235	pollen sperm cell differentiation	NCBITaxon:3398	Magnoliophyta	
 GO:0048236	plant-type sporogenesis	NCBITaxon:33090	Viridiplantae	
+GO:0048273	mitogen-activated protein kinase p38 binding	NCBITaxon:33208	Metazoa	
 GO:0048314	embryo sac morphogenesis	NCBITaxon:3398	Magnoliophyta	
 GO:0048364	root development	NCBITaxon:33090	Viridiplantae	
 GO:0048477	oogenesis	NCBITaxon:33208	Metazoa	
@@ -442,75 +617,158 @@ GO:0048623	seed germination on parent plant	NCBITaxon:33090	Viridiplantae
 GO:0048624	plantlet formation on parent plant	NCBITaxon:33090	Viridiplantae	
 GO:0048658	anther wall tapetum development	NCBITaxon:33090	Viridiplantae	
 GO:0048737	imaginal disc-derived appendage development	NCBITaxon:6656	Arthropoda	
+GO:0048750	compound eye corneal lens morphogenesis	NCBITaxon:6656	Arthropoda	
 GO:0048826	cotyledon morphogenesis	NCBITaxon:33090	Viridiplantae	
 GO:0048827	phyllome development	NCBITaxon:33090	Viridiplantae	
 GO:0048829	root cap development	NCBITaxon:33090	Viridiplantae	
 GO:0048838	release of seed from dormancy	NCBITaxon:33090	Viridiplantae	
 GO:0048840	otolith development	NCBITaxon:7742	Vertebrata <Metazoa>	
+GO:0050062	long-chain-fatty-acyl-CoA luciferin component reductase activity	NCBITaxon:2	Bacteria	
+GO:0050322	taurine-2-oxoglutarate transaminase activity	NCBITaxon:2	Bacteria	PMID:16535664
+GO:0050323	taurine dehydrogenase activity	NCBITaxon:2	Bacteria	PMID:15073291
+GO:0050325	tauropine dehydrogenase activity	NCBITaxon:33208	Metazoa	
+GO:0050803	regulation of synapse structure or activity	NCBITaxon:6072	Eumetazoa	
 GO:0050845	teichuronic acid biosynthetic process	NCBITaxon:2	Bacteria	
+GO:0050870	positive regulation of T cell activation	NCBITaxon:6072	Eumetazoa	
 GO:0050877	nervous system process	NCBITaxon:33208	Metazoa	
+GO:0050900	leukocyte migration	NCBITaxon:7742	Vertebrata <Metazoa>	
 GO:0050959	echolocation	NCBITaxon:32524	Amniota	https://en.wikipedia.org/wiki/Animal_echolocation
 GO:0051077	secondary cell septum	NCBITaxon:2759	Eukaryota	
 GO:0051300	spindle pole body organization	NCBITaxon:4751	Fungi	
 GO:0051321	meiotic cell cycle	NCBITaxon:2759	Eukaryota	
 GO:0051417	microtubule nucleation by spindle pole body	NCBITaxon:4751	Fungi	
+GO:0051457	maintenance of protein location in nucleus	NCBITaxon:2759	Eukaryota	
+GO:0051457	maintenance of protein location in nucleus	NCBITaxon:2759	Eukaryota	
+GO:0051560	mitochondrial calcium ion homeostasis	NCBITaxon:2759	Eukaryota	
 GO:0051640	organelle localization	NCBITaxon:2759	Eukaryota	
+GO:0051649	establishment of localization in cell	NCBITaxon:131567	cellular organisms	
 GO:0051663	oocyte nucleus localization involved in oocyte dorsal/ventral axis specification	NCBITaxon:6656	Arthropoda	
+GO:0051882	mitochondrial depolarization	NCBITaxon:2759	Eukaryota	
+GO:0051960	regulation of nervous system development	NCBITaxon:6072	Eumetazoa	
 GO:0052324	plant-type cell wall cellulose biosynthetic process	NCBITaxon:33090	Viridiplantae	
 GO:0052325	cell wall pectin biosynthetic process	NCBITaxon:33090	Viridiplantae	
+GO:0052704	ergothioneine biosynthesis from histidine via gamma-glutamyl-hercynylcysteine sulfoxide	NCBITaxon:2	Bacteria	
+GO:0052907	23S rRNA (adenine(1618)-N(6))-methyltransferase activity	NCBITaxon:Union_0000004	Prokaryota	
 GO:0055044	symplast	NCBITaxon:33090	Viridiplantae	
 GO:0055045	antipodal cell degeneration	NCBITaxon:3398	Magnoliophyta	
 GO:0055046	microgametogenesis	NCBITaxon:3398	Magnoliophyta	
 GO:0055051	ATP-binding cassette (ABC) transporter complex, integrated substrate binding	NCBITaxon:2759	Eukaryota	
 GO:0055052	ATP-binding cassette (ABC) transporter complex, substrate-binding subunit-containing	NCBITaxon:Union_0000004	Prokaryota	
+GO:0055120	striated muscle dense body	NCBITaxon:6072	Eumetazoa	
 GO:0060033	anatomical structure regression	NCBITaxon:2759	Eukaryota	
 GO:0060102	collagen and cuticulin-based cuticle extracellular matrix	NCBITaxon:33213	Bilateria	
 GO:0060111	alae of collagen and cuticulin-based cuticle extracellular matrix	NCBITaxon:33213	Bilateria	
 GO:0060156	milk ejection reflex	NCBITaxon:40674	Mammalia	
 GO:0060271	cilium assembly	NCBITaxon:2759	Eukaryota	
+GO:0060417 	yolk	NCBITaxon:6072	Eumetazoa	
+GO:0060418	yolk plasma	NCBITaxon:33208	Metazoa	
 GO:0060856	establishment of blood-brain barrier	NCBITaxon:6072	Eumetazoa	
+GO:0060918	auxin transport	NCBITaxon:33090	Viridiplantae	
+GO:0060998	regulation of dendritic spine development	NCBITaxon:7742	Vertebrata <Metazoa>	
+GO:0061061	muscle structure development	NCBITaxon:6072	Eumetazoa	
 GO:0061319	nephrocyte differentiation	NCBITaxon:50557	Insecta	
+GO:0061468	karyomere	NCBITaxon:2759	Eukaryota	
+GO:0061512	protein localization to cilium	NCBITaxon:2759	Eukaryota	
 GO:0061639	Cdv-dependent cytokinesis	NCBITaxon:2157	Archaea	
 GO:0061701	bacterial outer membrane vesicle	NCBITaxon:2	Bacteria	
 GO:0061772	drug transport across blood-nerve barrier	NCBITaxon:7742	Vertebrata <Metazoa>	
 GO:0061822	ciliary cap	NCBITaxon:50557	Insecta	
 GO:0061823	ring centriole	NCBITaxon:50557	Insecta	
+GO:0062089	regulation of taurine biosynthetic process	NCBITaxon:33208	Metazoa	
+GO:0062097	chemosynthesis	NCBITaxon:Union_0000004	Prokaryota	
+GO:0062200	RAM/MOR signaling pathway	NCBITaxon:4751	Fungi	PMID:23212898
 GO:0070057	prospore membrane spindle pole body attachment site	NCBITaxon:4751	Fungi	
+GO:0070074	mononeme	NCBITaxon:2759	Eukaryota	
+GO:0070124	mitochondrial translational initiation	NCBITaxon:2759	Eukaryota	
+GO:0070125	mitochondrial translational elongation	NCBITaxon:2759	Eukaryota	
+GO:0070126	mitochondrial translational termination	NCBITaxon:2759	Eukaryota	
+GO:0070143	mitochondrial alanyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070144	mitochondrial arginyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070145	mitochondrial asparaginyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070146	mitochondrial aspartyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070147	mitochondrial cysteinyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070148	mitochondrial glutaminyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070149	mitochondrial glutamyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070150	mitochondrial glycyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070151	mitochondrial histidyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070152	mitochondrial isoleucyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070153	mitochondrial leucyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070154	mitochondrial lysyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070155	mitochondrial methionyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070156	mitochondrial phenylalanyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070157	mitochondrial prolyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070158	mitochondrial seryl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070159	mitochondrial threonyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070183	mitochondrial tryptophanyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070184	mitochondrial tyrosyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
+GO:0070185	mitochondrial valyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
 GO:0070196	eukaryotic translation initiation factor 3 complex assembly	NCBITaxon:2759	Eukaryota	
 GO:0070258	inner membrane pellicle complex	NCBITaxon:5794	Apicomplexa	
+GO:0070324	thyroid hormone binding	NCBITaxon:6072	Eumetazoa	
+GO:0070478	nuclear-transcribed mRNA catabolic process, 3'-5' exonucleolytic nonsense-mediated decay	NCBITaxon:2759	Eukaryota	
+GO:0070479	nuclear-transcribed mRNA catabolic process, 5'-3' exonucleolytic nonsense-mediated decay	NCBITaxon:2759	Eukaryota	
 GO:0070527	platelet aggregation	NCBITaxon:33208	Metazoa	
+GO:0070531	BRCA1-A complex	NCBITaxon:6072	Eumetazoa	
 GO:0070631	spindle pole body localization	NCBITaxon:4751	Fungi	
 GO:0070648	formin-nucleated actin cable	NCBITaxon:2759	Eukaryota	
+GO:0070661	leukocyte proliferation	NCBITaxon:7742	Vertebrata <Metazoa>	
+GO:0070899	mitochondrial tRNA wobble uridine modification	NCBITaxon:2759	Eukaryota	
+GO:0070900	mitochondrial tRNA modification	NCBITaxon:2759	Eukaryota	
+GO:0070901	mitochondrial tRNA methylation	NCBITaxon:2759	Eukaryota	
+GO:0070902	mitochondrial tRNA pseudouridine synthesis	NCBITaxon:2759	Eukaryota	
+GO:0070903	mitochondrial tRNA thio-modification	NCBITaxon:2759	Eukaryota	
+GO:0071027	nuclear RNA surveillance	NCBITaxon:2759	Eukaryota	
+GO:0071027	nuclear RNA surveillance	NCBITaxon:2759	Eukaryota	
 GO:0071074	eukaryotic initiation factor eIF2 binding	NCBITaxon:2759	Eukaryota	
+GO:0071142 	homomeric SMAD protein complex	NCBITaxon:6072	Eumetazoa	
+GO:0071212	subsynaptic reticulum	NCBITaxon:2759	Eukaryota	
 GO:0071629	cytoplasm protein quality control by the ubiquitin-proteasome system	NCBITaxon:2759	Eukaryota	
 GO:0071630	nuclear protein quality control by the ubiquitin-proteasome system	NCBITaxon:2759	Eukaryota	
 GO:0071669	plant-type cell wall organization or biogenesis	NCBITaxon:33090	Viridiplantae	
 GO:0071766	Actinobacterium-type cell wall biogenesis	NCBITaxon:2	Bacteria	
+GO:0071875	adrenergic receptor signaling pathway	NCBITaxon:6072	Eumetazoa	
+GO:0071887	leukocyte apoptotic process	NCBITaxon:7742	Vertebrata <Metazoa>	
 GO:0071938	vitamin A transport	NCBITaxon:33208	Metazoa	
 GO:0071973	bacterial-type flagellum-dependent cell motility	NCBITaxon:2	Bacteria	
+GO:0071990	maintenance of protein location to spindle pole body	NCBITaxon:4751	Fungi	
 GO:0072002	Malpighian tubule development	NCBITaxon:50557	Insecta	
 GO:0072325	vulval cell fate commitment	NCBITaxon:6231	Nematoda	
 GO:0072326	vulval cell fate determination	NCBITaxon:6231	Nematoda	
 GO:0072327	vulval cell fate specification	NCBITaxon:6231	Nematoda	
+GO:0072331	signal transduction by p53 class mediator	NCBITaxon:6072	Eumetazoa	
+GO:0072487	MSL complex	NCBITaxon:33208	Metazoa	
+GO:0072562	blood microparticle	NCBITaxon:6072	Eumetazoa	
 GO:0072564	blood microparticle formation	NCBITaxon:33208	Metazoa	
 GO:0072580	bacterial-type EF-P lysine modification	NCBITaxon:2	Bacteria	
+GO:0072656	maintenance of protein location in mitochondrion	NCBITaxon:2759	Eukaryota	
 GO:0072690	single-celled organism vegetative growth phase	NCBITaxon:Union_0000023	Fungi or Bacteria or Archaea	
 GO:0075321	oomycete sporangium development	NCBITaxon:4762	Oomycetes	
 GO:0080086	stamen filament development	NCBITaxon:33090	Viridiplantae	
+GO:0080156	mitochondrial mRNA modification	NCBITaxon:2759	Eukaryota	
+GO:0080161	auxin transmembrane transporter activity	NCBITaxon:33090	Viridiplantae	
+GO:0080175	phragmoplast microtubule organization	NCBITaxon:33090	Viridiplantae	
 GO:0080186	developmental vegetative growth	NCBITaxon:33090	Viridiplantae	
+GO:0080188	gene silencing by RNA-directed DNA methylation	NCBITaxon:33090	Viridiplantae	PMID:33031395
+GO:0086036	regulation of cardiac muscle cell membrane potential	NCBITaxon:33208	Metazoa	
+GO:0090139	mitochondrial DNA packaging	NCBITaxon:2759	Eukaryota	
 GO:0090210	regulation of establishment of blood-brain barrier	NCBITaxon:6072	Eumetazoa	
 GO:0090395	plant cell papilla	NCBITaxon:33090	Viridiplantae	
 GO:0090399	replicative senescence	NCBITaxon:33208	Metazoa	
 GO:0090540	bacterial cellulose biosynthetic process	NCBITaxon:2	Bacteria	
 GO:0090558	plant epidermis development	NCBITaxon:33090	Viridiplantae	
 GO:0090597	nematode male tail mating organ morphogenesis	NCBITaxon:6231	Nematoda	
+GO:0090615	mitochondrial mRNA processing	NCBITaxon:2759	Eukaryota	
+GO:0090616	mitochondrial mRNA 3'-end processing	NCBITaxon:2759	Eukaryota	
 GO:0090639	phosphatidylcholine biosynthesis from choline and CDP-diacylglycerol	NCBITaxon:2	Bacteria	
+GO:0090646	mitochondrial tRNA processing	NCBITaxon:2759	Eukaryota	
+GO:0090652	basolateral cytoplasm	NCBITaxon:33208	Metazoa	
 GO:0097010	eukaryotic translation initiation factor 4F complex assembly	NCBITaxon:2759	Eukaryota	
 GO:0097094	craniofacial suture morphogenesis	NCBITaxon:7742	Vertebrata <Metazoa>	
 GO:0097195	pilomotor reflex	NCBITaxon:40674	Mammalia	
 GO:0097206	nephrocyte filtration	NCBITaxon:50557	Insecta	
 GO:0097207	bud dormancy process	NCBITaxon:33090	Viridiplantae	
 GO:0097218	sieve plate	NCBITaxon:3398	Magnoliophyta	
+GO:0097222	mitochondrial mRNA polyadenylation	NCBITaxon:2759	Eukaryota	
 GO:0097347	TAM protein secretion complex	NCBITaxon:2	Bacteria	
 GO:0097387	capitate projection	NCBITaxon:7203	Brachycera	
 GO:0097413	Lewy body	NCBITaxon:33208	Metazoa	
@@ -559,38 +817,136 @@ GO:0097738	substrate mycelium formation	NCBITaxon:Union_0000020	Fungi or Bacteri
 GO:0097740	paraflagellar rod	NCBITaxon:33682	Euglenozoa	
 GO:0097741	mastigoneme	NCBITaxon:Union_0000031	Stramenopiles or Cryptophyta	
 GO:0097743	de novo centriole assembly via blepharoplast	NCBITaxon:35493	Streptophyta	
+GO:0097745	mitochondrial tRNA 5'-end processing	NCBITaxon:2759	Eukaryota	
 GO:0098046	type V protein secretion system complex	NCBITaxon:2	Bacteria	
 GO:0098536	deuterosome	NCBITaxon:33208	Metazoa	
 GO:0098593	goblet cell theca	NCBITaxon:33208	Metazoa	
+GO:0098706	iron ion import across cell outer membrane	NCBITaxon:2	Bacteria	
+GO:0098795	global gene silencing by mRNA cleavage	NCBITaxon:2	Bacteria	
+GO:0099003	vesicle-mediated transport in synapse	NCBITaxon:33208	Metazoa	
+GO:0099003	vesicle-mediated transport in synapse	NCBITaxon:33208	Metazoa	
+GO:0099536	synaptic signaling	NCBITaxon:33208	Metazoa	
+GO:0099546	protein catabolic process, modulating synaptic transmission	NCBITaxon:33208	Metazoa	
+GO:0099546	protein catabolic process, modulating synaptic transmission	NCBITaxon:33208	Metazoa	
+GO:0099547	regulation of translation at synapse, modulating synaptic transmission	NCBITaxon:33208	Metazoa	
+GO:0099547	regulation of translation at synapse, modulating synaptic transmission	NCBITaxon:33208	Metazoa	
+GO:0099563	modification of synaptic structure	NCBITaxon:33208	Metazoa	
+GO:0099574	regulation of protein catabolic process at synapse, modulating synaptic transmission	NCBITaxon:33208	Metazoa	
+GO:0099574	regulation of protein catabolic process at synapse, modulating synaptic transmission	NCBITaxon:33208	Metazoa	
 GO:0099622	cardiac muscle cell membrane repolarization	NCBITaxon:33208	Metazoa	
+GO:0099643	signal release from synapse	NCBITaxon:33208	Metazoa	
+GO:0099643	signal release from synapse	NCBITaxon:33208	Metazoa	
+GO:0101024	mitotic nuclear membrane organization	NCBITaxon:2759	Eukaryota	
+GO:0101026	mitotic nuclear membrane biogenesis	NCBITaxon:2759	Eukaryota	
+GO:0103012	ferredoxin-thioredoxin reductase activity	NCBITaxon_Union:0000002	Viridiplantae or Cyanobacteria	
+GO:0106059	tRNA (cytidine 56-2'-O)-methyltransferase activity	NCBITaxon:2157	Archaea	
 GO:0106123	reservosome	NCBITaxon:47570	Schizotrypanum	
 GO:0106124	reservosome lumen	NCBITaxon:47570	Schizotrypanum	
 GO:0106125	reservosome matrix	NCBITaxon:47570	Schizotrypanum	
 GO:0106126	reservosome membrane	NCBITaxon:47570	Schizotrypanum	
+GO:0106314	nitrite reductase (NADPH) activity	NCBITaxon:2759	Eukaryota	
+GO:0120098 	procentriole	NCBITaxon:6072	Eumetazoa	  
+GO:0120099 	procentriole replication complex	NCBITaxon:6072	Eumetazoa	
 GO:0120118	flagella connector	NCBITaxon:5653	Kinetoplastida	
 GO:0120119	flagellum attachment zone	NCBITaxon:5653	Kinetoplastida	
 GO:0120120	bilobe structure	NCBITaxon:5653	Kinetoplastida	
 GO:0120121	tripartite attachment complex	NCBITaxon:5653	Kinetoplastida	
+GO:0120259	7SK snRNP	NCBITaxon:33208	Metazoa	
+GO:0120260	ciliary microtubule quartet	NCBITaxon:5653	Kinetoplastida	
+GO:0120268	paraflagellar rod assembly	NCBITaxon:33682	Euglenozoa	
+GO:0120269	ciliary centrin arm	NCBITaxon:5653	Kinetoplastea	
+GO:0120273	ciliary centrin arm assembly	NCBITaxon:5653	Kinetoplastea	
+GO:0120307	Hechtian strand	NCBITaxon:33090	Viridiplantae	
+GO:0120309	cilium attachment to cell body	NCBITaxon:5653	Kinetoplastida	
+GO:0120310	amastigogenesis	NCBITaxon:5654	Trypanosomatidae	
+GO:0120324	procyclogenesis	NCBITaxon:5654	Trypanosomatidae	
+GO:0120549	limit dextrin alpha-1,6-maltotetraose-hydrolase activity	NCBITaxon:2	Bacteria	
 GO:0140007	KICSTOR complex	NCBITaxon:7742	Vertebrata <Metazoa>	
 GO:0140022	cnida	NCBITaxon:6073	Cnidaria	
+GO:0140040	mitochondrial polycistronic RNA processing	NCBITaxon:2759	Eukaryota	
+GO:0140041	cellular detoxification of methylglyoxal	NCBITaxon:131567	cellular organisms	
+GO:0140053	mitochondrial gene expression	NCBITaxon:2759	Eukaryota	
+GO:0140094	structural constituent of cytoplasmic lattice	NCBITaxon:40674	Mammalia	
+GO:0140095	cytoplasmic lattice	NCBITaxon:40674	Mammalia	
+GO:0140241	translation at synapse	NCBITaxon:33208	Metazoa	
+GO:0140241	translation at synapse	NCBITaxon:33208	Metazoa	
+GO:0140243	regulation of translation at synapse	NCBITaxon:33208	Metazoa	
+GO:0140243	regulation of translation at synapse	NCBITaxon:33208	Metazoa	
+GO:0140246	protein catabolic process at synapse	NCBITaxon:33208	Metazoa	
+GO:0140246	protein catabolic process at synapse	NCBITaxon:33208	Metazoa	
+GO:0140250	regulation protein catabolic process at synapse	NCBITaxon:33208	Metazoa	
+GO:0140250	regulation protein catabolic process at synapse	NCBITaxon:33208	Metazoa	
 GO:0140266	Woronin body	NCBITaxon:4890	Ascomycota	
+GO:0140384	metacyclogenesis	NCBITaxon:5654	Trypanosomatidae	
+GO:0140400	embryonic sheath	NCBITaxon:6231	Nematoda	PMID:28526752
+GO:0140446	fumigermin biosynthetic process	NCBITaxon:4751	Fungi	
+GO:0140479	ergothioneine biosynthesis from histidine via hercynylcysteine sulfoxide synthase	NCBITaxon:4751	Fungi	
+GO:0140494	migrasome	NCBITaxon:7742	NCBITaxon:2759	Eukaryota  PMID:40712579|PMID:25342562
+GO:0140495	migracytosis	NCBITaxon:7742	Vertebrata <Metazoa>	
+GO:0140525	antipodal site	NCBITaxon:5653	Kinetoplastea	
+GO:0140528	bilobe structure assembly	NCBITaxon:5653	Kinetoplastea	
+GO:0140549	spore inner membrane	NCBITaxon:2	Bacteria	
+GO:0140582	adenylate cyclase-activating G protein-coupled cAMP receptor signaling pathway	NCBITaxon:33083	Dictyostelids	
+GO:0140604	mycofactocin biosynthetic process	NCBITaxon:Union_0000004	Prokaryota	
+GO:0140690	dihydropyrimidine dehydrogenase (NAD+) complex	NCBITaxon:2	Bacteria	
+GO:0140781	ilicicolin H biosynthetic process	NCBITaxon:4751	Fungi	
+GO:0140782	novofumigatonin biosynthetic process	NCBITaxon:4751	Fungi	
+GO:0140782	novofumigatonin biosynthetic process	NCBITaxon:4751	Fungi	
+GO:0140783	(M)-viriditoxin biosynthetic process	NCBITaxon:4751	Fungi	
+GO:0141035	CTP-dependent diacylglycerol kinase activity	NCBITaxon:4751	Fungi	
+GO:0141063	epigenetic programming in the central cell	NCBITaxon:33090	Viridiplantae	
+GO:0141065	maternal mRNA clearance	NCBITaxon:2759	Eukaryota	
+GO:0141091	transforming growth factor beta receptor superfamily signaling pathway	NCBITaxon:6072	Eumetazoa	
+GO:0141133	diphthine methyl ester synthase activity	NCBITaxon:2759	Eukaryota	PMID:24739148
+GO:0141153	glycerol-3-phosphate dehydrogenase (NADP+) activity	NCBITaxon:Union_0000004	Prokaryota	PMID:15557260
+GO:0141169	epigenetic 5-methylcytosine DNA demethylation, direct 5-methylcytosine excision pathway	NCBITaxon:33090	Viridiplantae	PMID:31546611
 GO:0150064	vertebrate eye-specific patterning	NCBITaxon:7742	Vertebrata <Metazoa>	
 GO:0150077	regulation of neuroinflammatory response	NCBITaxon:7742	Vertebrata <Metazoa>	
+GO:0150104	transport across blood-brain barrier	NCBITaxon:6072	Eumetazoa	
+GO:0160032	Toll receptor ligand protein activation cascade	NCBITaxon:50557	Insecta	
+GO:0160045	TMEM240-body	NCBITaxon:2759	Eukaryota	
+GO:0160062	cutin-based cuticle development	NCBITaxon:3193	Embryophyta	
+GO:0160092	hemozoin formation complex	NCBITaxon:5820	Plasmodium	
+GO:0160175	somatic muscle attachment to chitin-based cuticle	NCBITaxon:6656	Arthropoda	
+GO:0160201	polaroplast	NCBITaxon:2759	Eukaryota	
+GO:0160208	fibrous body-membranous organelle	NCBITaxon:6231	Nematoda	
+GO:0160237	D-Ala-D-Ala dipeptidase activity	NCBITaxon:2	Bacteria	
+GO:0160253	de novo tRNA queuosine(34) biosynthetic process	NCBITaxon:2	Bacteria	
+GO:0160254	tRNA queuosine(34) biosynthetic process from salvaged queuosine	NCBITaxon:2	Bacteria	
+GO:0160269	sweat secretion	NCBITaxon:40674	Mammalia	
+GO:0170010	nonsense-mediated decay complex	NCBITaxon:2759	Eukaryota	
 GO:1900727	osmoregulated periplasmic glucan biosynthetic process	NCBITaxon:2	Bacteria	
+GO:1900864	mitochondrial RNA modification	NCBITaxon:2759	Eukaryota	
+GO:1902896	terminal web assembly	NCBITaxon:6072	Eumetazoa	
 GO:1903000	regulation of lipid transport across blood-brain barrier	NCBITaxon:6072	Eumetazoa	
 GO:1903395	regulation of secondary cell septum biogenesis	NCBITaxon:2759	Eukaryota	
+GO:1904381	Golgi apparatus mannose trimming	NCBITaxon:2759	Eukaryota	
 GO:1905266	blasticidin S biosynthetic process	NCBITaxon:2	Bacteria	
 GO:1905393	plant organ formation	NCBITaxon:33090	Viridiplantae	
 GO:1905603	regulation of maintenance of permeability of blood-brain barrier	NCBITaxon:6072	Eumetazoa	
 GO:1905756	regulation of primary cell septum biogenesis	NCBITaxon:2759	Eukaryota	
+GO:1905951	mitochondrion DNA recombination	NCBITaxon:2759	Eukaryota	
 GO:1990061	bacterial degradosome	NCBITaxon:2	Bacteria	
 GO:1990077	primosome complex	NCBITaxon:Union_0000004	Prokaryota	
 GO:1990111	spermatoproteasome complex	NCBITaxon:33208	Metazoa	
+GO:1990180	mitochondrial tRNA 3'-end processing	NCBITaxon:2759	Eukaryota	
 GO:1990195	macrolide transmembrane transporter complex	NCBITaxon:2	Bacteria	
+GO:1990198	ModE complex	NCBITaxon:2	Bacteria	
+GO:1990205	taurine dioxygenase complex	NCBITaxon:2	Bacteria	
+GO:1990220	GroEL-GroES	NCBITaxon:Union_0000004	Prokaryota	
+GO:1990257	piccolo-bassoon transport vesicle	NCBITaxon:6072	Eumetazoa	
 GO:1990344	secondary cell septum biogenesis	NCBITaxon:2759	Eukaryota	
+GO:1990357	terminal web	NCBITaxon:6072	Eumetazoa	
 GO:1990379	lipid transport across blood-brain barrier	NCBITaxon:6072	Eumetazoa	
+GO:1990413	eyespot apparatus	NCBITaxon:2759	Eukaryota	
+GO:1990448	exon-exon junction complex binding	NCBITaxon:2759	Eukaryota	
+GO:1990462	omegasome	NCBITaxon:2759	Eukaryota	
 GO:1990490	archaeal proton-transporting A-type ATPase complex	NCBITaxon:2157	Archaea	
+GO:1990523	bone regeneration	NCBITaxon:6072	Eumetazoa	
 GO:1990586	divisome complex	NCBITaxon:Union_0000004	Prokaryota	
+GO:1990765	colon smooth muscle contraction	NCBITaxon:7742	Vertebrata <Metazoa>	
+GO:1990770	small intestine smooth muscle contraction	NCBITaxon:7742	Vertebrata <Metazoa>	
+GO:1990794	basolateral part of cell	NCBITaxon:33208	Metazoa	
 GO:1990901	old cell pole	NCBITaxon:2	Bacteria	
 GO:1990902	new cell pole	NCBITaxon:2	Bacteria	
 GO:1990905	dinoflagellate peduncle	NCBITaxon:2864	Dinophyceae	
@@ -598,356 +954,11 @@ GO:1990936	vascular smooth muscle cell dedifferentiation	NCBITaxon:33208	Metazoa
 GO:1990962	drug transport across blood-brain barrier	NCBITaxon:6072	Eumetazoa	
 GO:1990963	establishment of blood-retinal barrier	NCBITaxon:7742	Vertebrata <Metazoa>	
 GO:1990965	cytosylglucuronate decarboxylase activity	NCBITaxon:2	Bacteria	
-GO:2001310	gliotoxin biosynthetic process	NCBITaxon:4751	Fungi	
-GO:0062097	chemosynthesis	NCBITaxon:Union_0000004	Prokaryota	
-GO:0061512	protein localization to cilium	NCBITaxon:2759	Eukaryota	
-GO:0098706	iron ion import across cell outer membrane	NCBITaxon:2	Bacteria	
-GO:0047077	Photinus-luciferin 4-monooxygenase (ATP-hydrolyzing) activity	NCBITaxon:71193	Elateroidea	
-GO:0061061	muscle structure development	NCBITaxon:6072	Eumetazoa	
-GO:0009271	phage shock	NCBITaxon:2	Bacteria	
-GO:0018189	pyrroloquinoline quinone biosynthetic process	NCBITaxon:2	Bacteria	
-GO:0030034	microvillar actin bundle assembly	NCBITaxon:33208	Metazoa	
-GO:0033693	neurofilament bundle assembly	NCBITaxon:33208	Metazoa	
-GO:0002499	proteolysis within endosome associated with antigen processing and presentation	NCBITaxon:2759	Eukaryota	
-GO:0032468	Golgi calcium ion homeostasis	NCBITaxon:2759	Eukaryota	
-GO:0033260	nuclear DNA replication	NCBITaxon:2759	Eukaryota	
-GO:0033260	nuclear DNA replication	NCBITaxon:2759	Eukaryota	
-GO:0042073	intraciliary transport	NCBITaxon:2759	Eukaryota	
-GO:0099003	vesicle-mediated transport in synapse	NCBITaxon:33208	Metazoa	
-GO:0099003	vesicle-mediated transport in synapse	NCBITaxon:33208	Metazoa	
-GO:0099643	signal release from synapse	NCBITaxon:33208	Metazoa	
-GO:0099643	signal release from synapse	NCBITaxon:33208	Metazoa	
-GO:0140053	mitochondrial gene expression	NCBITaxon:2759	Eukaryota	
-GO:2000827	mitochondrial RNA surveillance	NCBITaxon:2759	Eukaryota	
-GO:0051560	mitochondrial calcium ion homeostasis	NCBITaxon:2759	Eukaryota	
-GO:0070124	mitochondrial translational initiation	NCBITaxon:2759	Eukaryota	
-GO:0070125	mitochondrial translational elongation	NCBITaxon:2759	Eukaryota	
-GO:0070143	mitochondrial alanyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070144	mitochondrial arginyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070146	mitochondrial aspartyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070147	mitochondrial cysteinyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070150	mitochondrial glycyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070151	mitochondrial histidyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070152	mitochondrial isoleucyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070155	mitochondrial methionyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070157	mitochondrial prolyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070159	mitochondrial threonyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070183	mitochondrial tryptophanyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070184	mitochondrial tyrosyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070185	mitochondrial valyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070899	mitochondrial tRNA wobble uridine modification	NCBITaxon:2759	Eukaryota	
-GO:0070900	mitochondrial tRNA modification	NCBITaxon:2759	Eukaryota	
-GO:0070902	mitochondrial tRNA pseudouridine synthesis	NCBITaxon:2759	Eukaryota	
-GO:0070903	mitochondrial tRNA thio-modification	NCBITaxon:2759	Eukaryota	
-GO:0071990	maintenance of protein location to spindle pole body	NCBITaxon:4751	Fungi	
-GO:0072656	maintenance of protein location in mitochondrion	NCBITaxon:2759	Eukaryota	
-GO:0080156	mitochondrial mRNA modification	NCBITaxon:2759	Eukaryota	
-GO:0090139	mitochondrial DNA packaging	NCBITaxon:2759	Eukaryota	
-GO:0090615	mitochondrial mRNA processing	NCBITaxon:2759	Eukaryota	
-GO:0090646	mitochondrial tRNA processing	NCBITaxon:2759	Eukaryota	
-GO:0097222	mitochondrial mRNA polyadenylation	NCBITaxon:2759	Eukaryota	
-GO:0097745	mitochondrial tRNA 5'-end processing	NCBITaxon:2759	Eukaryota	
-GO:0099546	protein catabolic process, modulating synaptic transmission	NCBITaxon:33208	Metazoa	
-GO:0099546	protein catabolic process, modulating synaptic transmission	NCBITaxon:33208	Metazoa	
-GO:0099547	regulation of translation at synapse, modulating synaptic transmission	NCBITaxon:33208	Metazoa	
-GO:0099547	regulation of translation at synapse, modulating synaptic transmission	NCBITaxon:33208	Metazoa	
-GO:0099574	regulation of protein catabolic process at synapse, modulating synaptic transmission	NCBITaxon:33208	Metazoa	
-GO:0099574	regulation of protein catabolic process at synapse, modulating synaptic transmission	NCBITaxon:33208	Metazoa	
-GO:0140241	translation at synapse	NCBITaxon:33208	Metazoa	
-GO:0140241	translation at synapse	NCBITaxon:33208	Metazoa	
-GO:0140243	regulation of translation at synapse	NCBITaxon:33208	Metazoa	
-GO:0140243	regulation of translation at synapse	NCBITaxon:33208	Metazoa	
-GO:0140246	protein catabolic process at synapse	NCBITaxon:33208	Metazoa	
-GO:0140246	protein catabolic process at synapse	NCBITaxon:33208	Metazoa	
-GO:0140250	regulation protein catabolic process at synapse	NCBITaxon:33208	Metazoa	
-GO:0140250	regulation protein catabolic process at synapse	NCBITaxon:33208	Metazoa	
-GO:1904381	Golgi apparatus mannose trimming	NCBITaxon:2759	Eukaryota	
-GO:1905951	mitochondrion DNA recombination	NCBITaxon:2759	Eukaryota	
-GO:1990180	mitochondrial tRNA 3'-end processing	NCBITaxon:2759	Eukaryota	
-GO:0000957	mitochondrial RNA catabolic process	NCBITaxon:2759	Eukaryota	
-GO:0000958	mitochondrial mRNA catabolic process	NCBITaxon:2759	Eukaryota	
-GO:0000959	mitochondrial RNA metabolic process	NCBITaxon:2759	Eukaryota	
-GO:0000963	mitochondrial RNA processing	NCBITaxon:2759	Eukaryota	
-GO:0000964	mitochondrial RNA 5'-end processing	NCBITaxon:2759	Eukaryota	
-GO:0000965	mitochondrial RNA 3'-end processing	NCBITaxon:2759	Eukaryota	
-GO:0002227	innate immune response in mucosa	NCBITaxon:7711	Chordata	
-GO:0002384	hepatic immune response	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0002388	immune response in Peyer's patch	NCBITaxon:32524	Amniota	
-GO:0002389	tolerance induction in Peyer's patch	NCBITaxon:32524	Amniota	
-GO:0005214	structural constituent of chitin-based cuticle	NCBITaxon:6656	Arthropoda	
-GO:0006264	mitochondrial DNA replication	NCBITaxon:2759	Eukaryota	
-GO:0006390	mitochondrial transcription	NCBITaxon:2759	Eukaryota	
-GO:0006393	termination of mitochondrial transcription	NCBITaxon:2759	Eukaryota	
-GO:0007006	mitochondrial membrane organization	NCBITaxon:2759	Eukaryota	
-GO:0008316	structural constituent of vitelline membrane	NCBITaxon:33213	Bilateria	
-GO:0014714	myoblast fate commitment in head	NCBITaxon:33213	Bilateria	
-GO:0019093	mitochondrial RNA localization	NCBITaxon:2759	Eukaryota	
-GO:0019725	cellular homeostasis	NCBITaxon:131567	cellular organisms	
-GO:0019911	structural constituent of myelin sheath	NCBITaxon:33208	Metazoa	
-GO:0032042	mitochondrial DNA metabolic process	NCBITaxon:2759	Eukaryota	
-GO:0032043	mitochondrial DNA catabolic process	NCBITaxon:2759	Eukaryota	
-GO:0032469	endoplasmic reticulum calcium ion homeostasis	NCBITaxon:2759	Eukaryota	
-GO:0032507	maintenance of protein location in cell	NCBITaxon:131567	cellular organisms	
-GO:0032543	mitochondrial translation	NCBITaxon:2759	Eukaryota	
-GO:0033615	mitochondrial proton-transporting ATP synthase complex assembly	NCBITaxon:2759	Eukaryota	
-GO:0033617	mitochondrial respiratory chain complex IV assembly	NCBITaxon:2759	Eukaryota	
-GO:0034551	mitochondrial respiratory chain complex III assembly	NCBITaxon:2759	Eukaryota	
-GO:0034553	mitochondrial respiratory chain complex II assembly	NCBITaxon:2759	Eukaryota	
-GO:0034982	mitochondrial protein processing	NCBITaxon:2759	Eukaryota	
-GO:0035437	maintenance of protein localization in endoplasmic reticulum	NCBITaxon:2759	Eukaryota	
-GO:0035694	mitochondrial protein catabolic process	NCBITaxon:2759	Eukaryota	
-GO:0035804	structural constituent of egg coat	NCBITaxon:33208	Metazoa	
-GO:0036386	bacterial nucleoid DNA packaging	NCBITaxon:2	Bacteria	
-GO:0042775	mitochondrial ATP synthesis coupled electron transport	NCBITaxon:2759	Eukaryota	
-GO:0042776	mitochondrial ATP synthesis coupled proton transport	NCBITaxon:2759	Eukaryota	
-GO:0043504	mitochondrial DNA repair	NCBITaxon:2759	Eukaryota	
-GO:0051457	maintenance of protein location in nucleus	NCBITaxon:2759	Eukaryota	
-GO:0051457	maintenance of protein location in nucleus	NCBITaxon:2759	Eukaryota	
-GO:0051649	establishment of localization in cell	NCBITaxon:131567	cellular organisms	
-GO:0048058	compound eye corneal lens development	NCBITaxon:6656	Arthropoda	
-GO:0048750	compound eye corneal lens morphogenesis	NCBITaxon:6656	Arthropoda	
-GO:0051882	mitochondrial depolarization	NCBITaxon:2759	Eukaryota	
-GO:0070126	mitochondrial translational termination	NCBITaxon:2759	Eukaryota	
-GO:0070145	mitochondrial asparaginyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070148	mitochondrial glutaminyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070149	mitochondrial glutamyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070153	mitochondrial leucyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070154	mitochondrial lysyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070156	mitochondrial phenylalanyl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070158	mitochondrial seryl-tRNA aminoacylation	NCBITaxon:2759	Eukaryota	
-GO:0070901	mitochondrial tRNA methylation	NCBITaxon:2759	Eukaryota	
-GO:0071027	nuclear RNA surveillance	NCBITaxon:2759	Eukaryota	
-GO:0071027	nuclear RNA surveillance	NCBITaxon:2759	Eukaryota	
-GO:0090616	mitochondrial mRNA 3'-end processing	NCBITaxon:2759	Eukaryota	
-GO:0140040	mitochondrial polycistronic RNA processing	NCBITaxon:2759	Eukaryota	
-GO:0140041	cellular detoxification of methylglyoxal	NCBITaxon:131567	cellular organisms	
-GO:1900864	mitochondrial RNA modification	NCBITaxon:2759	Eukaryota	
-GO:1990770	small intestine smooth muscle contraction	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0008147	structural constituent of bone	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0021533	cell differentiation in hindbrain	NCBITaxon:89593	Craniata <chordata>	
-GO:0021534	cell proliferation in hindbrain	NCBITaxon:89593	Craniata <chordata>	
-GO:0021535	cell migration in hindbrain	NCBITaxon:89593	Craniata <chordata>	
-GO:0022010	central nervous system myelination	NCBITaxon:33213	Bilateria	
-GO:0032286	central nervous system myelin maintenance	NCBITaxon:33213	Bilateria	
-GO:0032289	central nervous system myelin formation	NCBITaxon:33213	Bilateria	
-GO:0032291	axon ensheathment in central nervous system	NCBITaxon:33213	Bilateria	
-GO:0032293	non-myelinated axon ensheathment in central nervous system	NCBITaxon:33213	Bilateria	
-GO:0042302	structural constituent of cuticle	NCBITaxon:6072	Eumetazoa	
-GO:0042329	structural constituent of collagen and cuticulin-based cuticle	NCBITaxon:6231	Nematoda	
-GO:1990765	colon smooth muscle contraction	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0140384	metacyclogenesis	NCBITaxon:5654	Trypanosomatidae	
-GO:0150104	transport across blood-brain barrier	NCBITaxon:6072	Eumetazoa	
-GO:0009236	cobalamin biosynthetic process	NCBITaxon:Union_0000004	Prokaryota	
-GO:0006836	neurotransmitter transport	NCBITaxon:33208	Metazoa	
-GO:0140446	fumigermin biosynthetic process	NCBITaxon:4751	Fungi	
-GO:0036411	H-NS-Cnu complex	NCBITaxon:2	Bacteria	
-GO:1990198	ModE complex	NCBITaxon:2	Bacteria	
-GO:0052704	ergothioneine biosynthesis from histidine via gamma-glutamyl-hercynylcysteine sulfoxide	NCBITaxon:2	Bacteria	
-GO:0140479	ergothioneine biosynthesis from histidine via hercynylcysteine sulfoxide synthase	NCBITaxon:4751	Fungi	
-GO:0140495	migracytosis	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0120259	7SK snRNP	NCBITaxon:33208	Metazoa	
-GO:0120260	ciliary microtubule quartet	NCBITaxon:5653	Kinetoplastida	
-GO:0140525	antipodal site	NCBITaxon:5653	Kinetoplastea	
-GO:0140528	bilobe structure assembly	NCBITaxon:5653	Kinetoplastea	
-GO:0120268	paraflagellar rod assembly	NCBITaxon:33682	Euglenozoa	
-GO:0120269	ciliary centrin arm	NCBITaxon:5653	Kinetoplastea	
-GO:0120273	ciliary centrin arm assembly	NCBITaxon:5653	Kinetoplastea	
-GO:0101024	mitotic nuclear membrane organization	NCBITaxon:2759	Eukaryota	
-GO:0101026	mitotic nuclear membrane biogenesis	NCBITaxon:2759	Eukaryota	
-GO:0048273	mitogen-activated protein kinase p38 binding	NCBITaxon:33208	Metazoa	
-GO:0086036	regulation of cardiac muscle cell membrane potential	NCBITaxon:33208	Metazoa	
-GO:0042412	taurine biosynthetic process	NCBITaxon:33208	Metazoa	
-GO:0050323	taurine dehydrogenase activity	NCBITaxon:2	Bacteria	PMID:15073291
-GO:0031299	taurine-pyruvate aminotransferase activity	NCBITaxon:2	Bacteria	PMID:11082195
-GO:0050322	taurine-2-oxoglutarate transaminase activity	NCBITaxon:2	Bacteria	PMID:16535664
-GO:0062089	regulation of taurine biosynthetic process	NCBITaxon:33208	Metazoa	
-GO:0050325	tauropine dehydrogenase activity	NCBITaxon:33208	Metazoa	
-GO:0103012	ferredoxin-thioredoxin reductase activity	NCBITaxon_Union:0000002	Viridiplantae or Cyanobacteria	
-GO:0030386	ferredoxin:thioredoxin reductase complex	NCBITaxon_Union:0000002	Viridiplantae or Cyanobacteria	
-GO:0000908	taurine dioxygenase activity	NCBITaxon:2	Bacteria	
-GO:1990205	taurine dioxygenase complex	NCBITaxon:2	Bacteria	
-GO:0140549	spore inner membrane	NCBITaxon:2	Bacteria	
-GO:0045664	regulation of neuron differentiation	NCBITaxon:33208	Metazoa	
-GO:2001222	regulation of neuron migration	NCBITaxon:33208	Metazoa	
-GO:0009877	nodulation	NCBITaxon:33090	Viridiplantae	
-GO:0140582	adenylate cyclase-activating G protein-coupled cAMP receptor signaling pathway	NCBITaxon:33083	Dictyostelids	
-GO:0031039	macronucleus	NCBITaxon:5878	Ciliophora	
-GO:0031040	micronucleus	NCBITaxon:5878	Ciliophora	
-GO:0045120	pronucleus	NCBITaxon:33208	Metazoa	
-GO:0060418	yolk plasma	NCBITaxon:33208	Metazoa	
-GO:0090652	basolateral cytoplasm	NCBITaxon:33208	Metazoa	
-GO:1990794	basolateral part of cell	NCBITaxon:33208	Metazoa	
-GO:0016323	basolateral plasma membrane	NCBITaxon:33208	Metazoa	
-GO:0046868	mesosome	NCBITaxon:2	Bacteria	
-GO:0033012	porosome	NCBITaxon:6072	Eumetazoa	
-GO:0020023	kinetoplast	NCBITaxon:5653	Kinetoplastea	
-GO:0005009	insulin-activated receptor activity	NCBITaxon:6072	Eumetazoa	
-GO:0005899	insulin receptor complex	NCBITaxon:6072	Eumetazoa	
-GO:0008286	insulin receptor signaling pathway	NCBITaxon:6072	Eumetazoa	
-GO:0046626	regulation of insulin receptor signaling pathway	NCBITaxon:6072	Eumetazoa	
-GO:0140604	mycofactocin biosynthetic process	NCBITaxon:Union_0000004	Prokaryota	
-GO:0009486	cytochrome bo3 ubiquinol oxidase activity	NCBITaxon:2	Bacteria	
-GO:0008815	citrate (pro-3S)-lyase activity	NCBITaxon:2	Bacteria	
-GO:0009346	ATP-independent citrate lyase complex	NCBITaxon:2	Bacteria	
-GO:0009289	pilus	NCBITaxon:2	Bacteria	
-GO:0043711	pilus organization	NCBITaxon:2	Bacteria	
-GO:0120309	cilium attachment to cell body	NCBITaxon:5653	Kinetoplastida	
-GO:0120310	amastigogenesis	NCBITaxon:5654	Trypanosomatidae	
-GO:0120307	Hechtian strand	NCBITaxon:33090	Viridiplantae	
-GO:0007533	mating type switching	NCBITaxon:4751	Fungi	
-GO:0019035	viral integration complex	NCBITaxon:10239	Viruses	
-GO:0044105	L-xylulose reductase (NAD+) activity	NCBITaxon:4890	Ascomycota	
-GO:0120324	procyclogenesis	NCBITaxon:5654	Trypanosomatidae	
-GO:0140690	dihydropyrimidine dehydrogenase (NAD+) complex	NCBITaxon:2	Bacteria	
-GO:0004159	dihydropyrimidine dehydrogenase (NAD+) activity	NCBITaxon:2	Bacteria	
-GO:0017113	dihydropyrimidine dehydrogenase (NADP+) activity	NCBITaxon:2759	Eukaryota	
-GO:1990257	piccolo-bassoon transport vesicle	NCBITaxon:6072	Eumetazoa	
-GO:0043386	mycotoxin biosynthetic process	NCBITaxon:4751	Fungi	
-GO:0031469	bacterial microcompartment	NCBITaxon:2	Bacteria	
-GO:0040033	sRNA-mediated gene silencing	NCBITaxon:2	Bacteria	
-GO:0140782	novofumigatonin biosynthetic process	NCBITaxon:4751	Fungi	
-GO:0140781	ilicicolin H biosynthetic process	NCBITaxon:4751	Fungi	
-GO:0140782	novofumigatonin biosynthetic process	NCBITaxon:4751	Fungi	
-GO:0140783	(M)-viriditoxin biosynthetic process	NCBITaxon:4751	Fungi	
-GO:0007179	transforming growth factor beta receptor signaling pathway	NCBITaxon:33511	Deuterostomia	
-GO:0160032	Toll receptor ligand protein activation cascade	NCBITaxon:50557	Insecta	
-GO:0035244	peptidyl-arginine C-methyltransferase activity	NCBITaxon:2	Bacteria	
-GO:0045321	leukocyte activation	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0002443	leukocyte mediated immunity	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0050900	leukocyte migration	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0070661	leukocyte proliferation	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0001909	leukocyte mediated cytotoxicity	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0001776	leukocyte homeostasis	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0043299	leukocyte degranulation	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0007159	leukocyte cell-cell adhesion	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0071887	leukocyte apoptotic process	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0080175	phragmoplast microtubule organization	NCBITaxon:33090	Viridiplantae	
-GO:1902896	terminal web assembly	NCBITaxon:6072	Eumetazoa	
-GO:1990357	terminal web	NCBITaxon:6072	Eumetazoa	
-GO:0160062	cutin-based cuticle development	NCBITaxon:3193	Embryophyta	
-GO:0060417 	yolk	NCBITaxon:6072	Eumetazoa	
-GO:0005883 	neurofilament	NCBITaxon:6072	Eumetazoa	
-GO:0120098 	procentriole	NCBITaxon:6072	Eumetazoa	  
-GO:0120099 	procentriole replication complex	NCBITaxon:6072	Eumetazoa	
-GO:0071142 	homomeric SMAD protein complex	NCBITaxon:6072	Eumetazoa	
-GO:0036457	keratohyalin granule	NCBITaxon:6072	Eumetazoa	
-GO:0045169	fusome	NCBITaxon:6072	Eumetazoa	
-GO:0019812	type I site-specific deoxyribonuclease complex	NCBITaxon:Union_0000004	Prokaryota	
-GO:0009359	type II site-specific deoxyribonuclease complex	NCBITaxon:Union_0000004	Prokaryota	
-GO:0019813	type III site-specific deoxyribonuclease complex	NCBITaxon:Union_0000004	Prokaryota	
-GO:0032068	type IV site-specific deoxyribonuclease complex	NCBITaxon:Union_0000004	Prokaryota	
-GO:0009504	cell plate	NCBITaxon:33090	Viridiplantae	
-GO:0072562	blood microparticle	NCBITaxon:6072	Eumetazoa	
-GO:0050803	regulation of synapse structure or activity	NCBITaxon:6072	Eumetazoa	
-GO:1990523	bone regeneration	NCBITaxon:6072	Eumetazoa	
-GO:0010597	green leaf volatile biosynthetic process	NCBITaxon:33090	Viridiplantae	
-GO:0009524	phragmoplast	NCBITaxon:33090	Viridiplantae	
-GO:0022620	microgametophyte vegetative cell differentiation	NCBITaxon:58024	Spermatophyta	
-GO:0034587	piRNA processing	NCBITaxon:6072	Eumetazoa	
-GO:0099536	synaptic signaling	NCBITaxon:33208	Metazoa	
-GO:0030594	neurotransmitter receptor activity	NCBITaxon:33208	Metazoa	
-GO:0141035	CTP-dependent diacylglycerol kinase activity	NCBITaxon:4751	Fungi	
-GO:0019270	aerobactin biosynthetic process	NCBITaxon:Union_0000004	Prokaryota	
-GO:0005326	neurotransmitter transmembrane transporter activity	NCBITaxon:6072	Eumetazoa	
-GO:0001775	cell activation	NCBITaxon:33208	Metazoa	
-GO:0141063	epigenetic programming in the central cell	NCBITaxon:33090	Viridiplantae	
-GO:0160092	hemozoin formation complex	NCBITaxon:5820	Plasmodium	
-GO:0009048	dosage compensation by inactivation of X chromosome	NCBITaxon:32524	Amniota	PMID:19802707
-GO:0080188	gene silencing by RNA-directed DNA methylation	NCBITaxon:33090	Viridiplantae	PMID:33031395
-GO:0106059	tRNA (cytidine 56-2'-O)-methyltransferase activity	NCBITaxon:2157	Archaea	
-GO:0072487	MSL complex	NCBITaxon:33208	Metazoa	
-GO:0042597	periplasmic space	NCBITaxon:Union_0000023	Fungi or Bacteria or Archaea	PMID:15803654
-GO:0060918	auxin transport	NCBITaxon:33090	Viridiplantae	
 GO:2000012	regulation of auxin polar transport	NCBITaxon:33090	Viridiplantae	
-GO:0080161	auxin transmembrane transporter activity	NCBITaxon:33090	Viridiplantae	
-GO:0062200	RAM/MOR signaling pathway	NCBITaxon:4751	Fungi	PMID:23212898
-GO:0004164	diphthine synthase activity	NCBITaxon:2157	Archaea	PMID:24739148
-GO:0141133	diphthine methyl ester synthase activity	NCBITaxon:2759	Eukaryota	PMID:24739148
-GO:0141153	glycerol-3-phosphate dehydrogenase (NADP+) activity	NCBITaxon:Union_0000004	Prokaryota	PMID:15557260
-GO:0141091	transforming growth factor beta receptor superfamily signaling pathway	NCBITaxon:6072	Eumetazoa	
-GO:0141169	epigenetic 5-methylcytosine DNA demethylation, direct 5-methylcytosine excision pathway	NCBITaxon:33090	Viridiplantae	PMID:31546611
-GO:0072331	signal transduction by p53 class mediator	NCBITaxon:6072	Eumetazoa	
-GO:0042541	hemoglobin biosynthetic process	NCBITaxon:6072	Eumetazoa	
-GO:0032186	cellular bud neck septin ring organization	NCBITaxon:147537	Saccharomycotina	
-GO:0047522	15-oxoprostaglandin 13-oxidase activity	NCBITaxon:6072	Eumetazoa	
-GO:0006693	prostaglandin metabolic process	NCBITaxon:6072	Eumetazoa	
-GO:0071875	adrenergic receptor signaling pathway	NCBITaxon:6072	Eumetazoa	
-GO:0046850	regulation of bone remodeling	NCBITaxon:6072	Eumetazoa	
-GO:0055120	striated muscle dense body	NCBITaxon:6072	Eumetazoa	
-GO:0030097	hemopoiesis	NCBITaxon:6072	Eumetazoa	
-GO:0048168	regulation of neuronal synaptic plasticity	NCBITaxon:6072	Eumetazoa	
-GO:0052907	23S rRNA (adenine(1618)-N(6))-methyltransferase activity	NCBITaxon:Union_0000004	Prokaryota	
-GO:0043292	contractile muscle fiber	NCBITaxon:6072	Eumetazoa	
-GO:0160175	somatic muscle attachment to chitin-based cuticle	NCBITaxon:6656	Arthropoda	
-GO:0001734	mRNA (N6-adenosine)-methyltransferase activity	NCBITaxon:2759	Eukaryota	
+GO:2000622	regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay	NCBITaxon:2759	Eukaryota	
+GO:2000623	negative regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay	NCBITaxon:2759	Eukaryota	
+GO:2000624	positive regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay	NCBITaxon:2759	Eukaryota	
+GO:2000827	mitochondrial RNA surveillance	NCBITaxon:2759	Eukaryota	
+GO:2001222	regulation of neuron migration	NCBITaxon:33208	Metazoa	
+GO:2001310	gliotoxin biosynthetic process	NCBITaxon:4751	Fungi	
 xGO:0016605	PML body	NCBITaxon:6072	Eumetazoa	
-GO:0006699	bile acid biosynthetic process	NCBITaxon:6072	Eumetazoa	
-GO:0050870	positive regulation of T cell activation	NCBITaxon:6072	Eumetazoa	
-GO:0043123	positive regulation of canonical NF-kappaB signal transduction	NCBITaxon:6072	Eumetazoa	
-GO:0032727	positive regulation of interferon-alpha production	NCBITaxon:6072	Eumetazoa	
-GO:0032755	positive regulation of interleukin-6 production	NCBITaxon:6072	Eumetazoa	
-GO:0031643	positive regulation of myelination	NCBITaxon:6072	Eumetazoa	
-GO:0032729	positive regulation of type II interferon production	NCBITaxon:6072	Eumetazoa	
-GO:0046850	regulation of bone remodeling	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0060998	regulation of dendritic spine development	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0070324	thyroid hormone binding	NCBITaxon:6072	Eumetazoa	
-GO:0009887	animal organ morphogenesis	NCBITaxon:6072	Eumetazoa	
-GO:0070531	BRCA1-A complex	NCBITaxon:6072	Eumetazoa	
-GO:0031436	BRCA1-BARD1 complex	NCBITaxon:6072	Eumetazoa	
-GO:1990220	GroEL-GroES	NCBITaxon:Union_0000004	Prokaryota	
-GO:0010736	serum response element binding	NCBITaxon:6072	Eumetazoa	
-GO:0009887	animal organ morphogenesis	NCBITaxon:6072	Eumetazoa	
-GO:0010236	plastoquinone biosynthetic process	NCBITaxon:33090	Viridiplantae	
-GO:0051960	regulation of nervous system development	NCBITaxon:6072	Eumetazoa	
-GO:0030428	cell septum	NCBITaxon:Union_0000020	Fungi or Bacteria	
-GO:0018679	dibenzothiophene-5,5-dioxide monooxygenase activity	NCBITaxon:Union_0000004	Prokaryota	
-GO:0031639	plasminogen activation	NCBITaxon:7742	Vertebrata <Metazoa>	
-GO:0009331	glycerol-3-phosphate dehydrogenase complex	NCBITaxon:Union_0000004	Prokaryota	
-GO:0019833	ice nucleation activity	NCBITaxon:2	Bacteria	
-GO:0030941	chloroplast targeting sequence binding	NCBITaxon:33090	Viridiplantae	
-GO:0043715	2,3-diketo-5-methylthiopentyl-1-phosphate enolase activity	NCBITaxon:2	Bacteria	
-GO:0043716	2-hydroxy-3-keto-5-methylthiopentenyl-1-phosphate phosphatase activity	NCBITaxon:2	Bacteria	
-GO:0160237	D-Ala-D-Ala dipeptidase activity	NCBITaxon:2	Bacteria	
-GO:0140095	cytoplasmic lattice	NCBITaxon:40674	Mammalia	
-GO:0140094	structural constituent of cytoplasmic lattice	NCBITaxon:40674	Mammalia	
-GO:0034354	'de novo' NAD biosynthetic process from tryptophan	NCBITaxon:2759	Eukaryota	
-GO:0120549	limit dextrin alpha-1,6-maltotetraose-hydrolase activity	NCBITaxon:2	Bacteria	
-GO:0160253	de novo tRNA queuosine(34) biosynthetic process	NCBITaxon:2	Bacteria	
-GO:0160254	tRNA queuosine(34) biosynthetic process from salvaged queuosine	NCBITaxon:2	Bacteria	
-GO:0050062	long-chain-fatty-acyl-CoA luciferin component reductase activity	NCBITaxon:2	Bacteria	
-GO:0047474	long-chain fatty acid--protein ligase activity	NCBITaxon:2	Bacteria	
-GO:0106314	nitrite reductase (NADPH) activity	NCBITaxon:2759	Eukaryota	
-GO:0160269	sweat secretion	NCBITaxon:40674	Mammalia	
-GO:0043682	P-type divalent copper transporter activity	NCBITaxon:2	Bacteria	
-GO:0044222	anammoxosome	NCBITaxon:Union_0000004	Prokaryota	
-GO:0044223	pirellulosome	NCBITaxon:2	Bacteria	
-GO:0044227	methane-oxidizing organelle	NCBITaxon:Union_0000004	Prokaryota	
-GO:0005634	nucleus	NCBITaxon:2759	Eukaryota	
-GO:0005739	mitochondrion	NCBITaxon:2759	Eukaryota	
-GO:0005773	vacuole	NCBITaxon:2759	Eukaryota	
-GO:0005783	endoplasmic reticulum	NCBITaxon:2759	Eukaryota	
-GO:0005793	endoplasmic reticulum-Golgi intermediate compartment	NCBITaxon:2759	Eukaryota	
-GO:0005794	Golgi apparatus	NCBITaxon:2759	Eukaryota	
-GO:0005801	cis-Golgi network	NCBITaxon:2759	Eukaryota	
-GO:0010168	ER body	NCBITaxon:2759	Eukaryota	
-GO:0016007	mitochondrial derivative	NCBITaxon:2759	Eukaryota	
-GO:0020009	microneme	NCBITaxon:2759	Eukaryota	
-GO:0031094	platelet dense tubular network	NCBITaxon:2759	Eukaryota	
-GO:0032047	mitosome	NCBITaxon:2759	Eukaryota	
-GO:0033009	nucleomorph	NCBITaxon:33090	Viridiplantae	
-GO:0042579	microbody	NCBITaxon:2759	Eukaryota	
-GO:0042735	endosperm protein body	NCBITaxon:2759	Eukaryota	
-GO:0044311	exoneme	NCBITaxon:2759	Eukaryota	
-GO:0061468	karyomere	NCBITaxon:2759	Eukaryota	
-GO:0070074	mononeme	NCBITaxon:2759	Eukaryota	
-GO:0071212	subsynaptic reticulum	NCBITaxon:2759	Eukaryota	
-GO:0140494	migrasome	NCBITaxon:7742	NCBITaxon:2759	Eukaryota  PMID:40712579|PMID:25342562
-GO:0160045	TMEM240-body	NCBITaxon:2759	Eukaryota	
-GO:0160201	polaroplast	NCBITaxon:2759	Eukaryota	
-GO:0160208	fibrous body-membranous organelle	NCBITaxon:6231	Nematoda	
-GO:1990413	eyespot apparatus	NCBITaxon:2759	Eukaryota	
-GO:1990462	omegasome	NCBITaxon:2759	Eukaryota	
-GO:0019905	syntaxin binding	NCBITaxon:2	Bacteria	
-GO:0098795	global gene silencing by mRNA cleavage	NCBITaxon:2	Bacteria	
-GO:0140400	embryonic sheath	NCBITaxon:6231	Nematoda	PMID:28526752
-GO:0019658	bifid shunt	NCBITaxon:2	Bacteria	


### PR DESCRIPTION
**⚠️ EVALUATION ONLY - DO NOT MERGE ⚠️**

## Original Issue
[#31670: Taxon constraint: please add for GO:0070478 and similar terms](https://href.li/?https://github.com/geneontology/go-ontology/issues/31670)

## Original PR (human solution)
[#31676: Add new GO terms for Eukaryota and Bacteria](https://href.li/?https://github.com/geneontology/go-ontology/pull/31676)

## Agent Commits
- Add taxon constraints for nonsense-mediated decay (NMD) related terms

**Note**: This PR diff shows ONLY the agent's changes. The baseline is eval_base_branch.

## Agent Response - PR Comments
# Taxon Constraints for Nonsense-Mediated Decay Terms

## Summary

Added `only_in_taxon` constraints restricting 11 GO terms related to nonsense-mediated decay (NMD) to Eukaryota (NCBITaxon:2759). This addresses issue #31670, which reported bacterial annotations for GO:0070478 that should not exist since bacteria lack NMD machinery.

## Terms Modified

### Core NMD Pathway Terms
- **GO:0000184**: nuclear-transcribed mRNA catabolic process, nonsense-mediated decay
- **GO:0070478**: nuclear-transcribed mRNA catabolic process, 3'-5' exonucleolytic nonsense-mediated decay *(originally requested)*
- **GO:0070479**: nuclear-transcribed mRNA catabolic process, 5'-3' exonucleolytic nonsense-mediated decay
- **GO:0170010**: nonsense-mediated decay complex

### NMD Regulation Terms
- **GO:2000622**: regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay
- **GO:2000623**: negative regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay
- **GO:2000624**: positive regulation of nuclear-transcribed mRNA catabolic process, nonsense-mediated decay

### Related mRNA Processing Terms
- **GO:0000956**: nuclear-transcribed mRNA catabolic process *(mentioned in issue comments)*
- **GO:0141065**: maternal mRNA clearance *(mentioned in issue comments)*

### Exon Junction Complex Terms
- **GO:0035145**: exon-exon junction complex
- **GO:1990448**: exon-exon junction complex binding

## Biological Rationale

Nonsense-mediated decay is fundamentally a eukaryote-specific pathway that:

1. **Requires pre-mRNA splicing**: The EJC (exon junction complex) is deposited during splicing in the nucleus and serves as a marker for identifying premature termination codons. Prokaryotes largely lack splicing.

2. **Depends on exon junction complexes**: EJCs contain proteins like eIF4AIII, Y14, MAGOH, and MLN51 that mark exon-exon boundaries. These remain on mRNA after nuclear export and are used to detect PTCs during the pioneer round of translation.

3. **Requires nuclear-cytoplasmic compartmentalization**: NMD occurs after mRNA export from the nucleus during the first round of translation. Bacteria lack this spatial separation.

4. **Not found in prokaryotes**: Bacteria use trans-translation (involving tmRNA) as their mRNA quality control mechanism, which is mechanistically distinct from eukaryotic NMD.

## Research Conducted

Background research was performed using web searches and literature review (PMID:26773057, PMID:39486251). Key findings:

- NMD is universally present across eukaryotes (animals, plants, fungi)
- The pathway requires core factors UPF1, UPF2, and UPF3 that are conserved in eukaryotes
- Classical NMD as defined in eukaryotes is absent from prokaryotes
- Bacteria have evolved a different quality control mechanism (trans-translation)

Full research documentation available in RESEARCH.md (not committed per project guidelines).

## Validation

- ✓ Pre-validation: Ontology structure confirmed before changes
- ✓ Term search: All relevant NMD-related terms identified using obo-grep.pl
- ✓ Research: Background research confirms NMD is eukaryote-specific
- ✓ File format: All entries formatted correctly with proper tab separation
- ✓ Column validation: `make check_all_taxon_constraints_columns` passed
- ✓ No duplicates: Verified no duplicate entries for newly added terms

## Checklist

- [x] **PLAN**: Issue analyzed and plan created
- [x] **PRE-VALIDATION**: Current state validated (N/A for taxon constraints)
- [x] **RESEARCH**: Background research performed using web search and literature review
- [x] **TERM-SEARCH**: Relevant ontology terms identified using obo-grep.pl
- [x] **DESIGN-PATTERNS**: N/A (taxon constraints, not term creation/modification)
- [x] **EDITS**: Constraints added to src/taxon_constraints/only_in_taxon.tsv
- [x] **RELATIONSHIPS**: N/A (taxon constraints, not ontology edits)
- [x] **SPECIALIZED-EDITS**: /taxon-constraint skill used appropriately
- [x] **METADATA**: N/A (taxon constraints have no metadata beyond what was added)
- [x] **AUTOMATED-VALIDATION**: File format validation passed
- [x] **REFERENCE-VALIDATION**: PMIDs validated using linkml-reference-validator
- [x] **CHANGES-COMMITTED**: 
  - [x] **RELEVANT-FILES**: Only src/taxon_constraints/only_in_taxon.tsv modified
  - [x] **ACCURACY**: Changes are biologically correct based on research
  - [x] **ISSUE-ALIGNMENT**: Addresses issue #31670 and related terms
  - [x] **PR**: This PR created
  - [x] **Communicated**: Issue and PR comments prepared

## Decision: only_in_taxon vs never_in_taxon

Used `only_in_taxon` constraint (Eukaryota) rather than `never_in_taxon` (Bacteria) because:
- NMD is universally present in eukaryotes
- Single constraint naturally excludes all prokaryotes (Bacteria and Archaea)
- More parsimonious than multiple never_in_taxon constraints
- Follows existing patterns for similar nuclear/splicing-dependent processes

## Files Changed

- `src/taxon_constraints/only_in_taxon.tsv`: Added 11 entries, file re-sorted alphabetically by GO ID

## References

- PMID:26773057 - Hug et al. (2016) "Mechanism and regulation of the nonsense-mediated decay pathway"
- PMID:39486251 - Patro et al. (2024) "Nonsense-mediated mRNA decay: Physiological significance, mechanistic insights and future implications"
- Multiple web resources confirming NMD's eukaryote-specific nature and requirements

---
🤖 **Generated by claude agent**
- Runtime: `claude`
- Model: `claude-sonnet-4-5-20250929`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25847237983)

## Agent Response - Issue Comments
Changes committed in PR #<NN>.

Added taxon constraints (only_in_taxon: Eukaryota) for GO:0070478 and 10 related NMD terms as requested. Research confirms that nonsense-mediated decay is eukaryote-specific and requires features absent in bacteria (splicing, exon junction complexes, nuclear compartmentalization).

The constraints also address the terms mentioned by @pgaudet (GO:0000956 and GO:0141065) which were not previously in the file.

---
🤖 **Generated by claude agent**
- Runtime: `claude`
- Model: `claude-sonnet-4-5-20250929`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25847237983)

## Experiment Config
| Parameter | Value |
|-----------|-------|
| Model | `claude-sonnet-4-5-20250929` |
| Agent config | `ai4curation/go-ontology-agent-config@v9:.` |
| Iteration | `1` |
| URL prefix | `https://href.li/?` |
| Base branch | `eval-base-issue-31670` |

See workflow artifacts for full agent trace.