### PR TITLE
[DO NOT MERGE] eval #31051 i:1: Taxon constraint: GO:0046544 development of secondary male sexual characteristics (codex/gpt-5.4, .)

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -378,7 +378,7 @@ GO:0044782	cilium organization	NCBITaxon:2759	Eukaryota
 GO:0044787	bacterial-type DNA replication	NCBITaxon:2	Bacteria	
 GO:0044849	estrous cycle	NCBITaxon:32525	Theria <Mammalia>	
 GO:0044850	menstrual cycle	NCBITaxon:9443	Primates	
-GO:0045136	development of secondary sexual characteristics, sensu Metazoa	NCBITaxon:33208	Metazoa	https://github.com/geneontology/go-ontology/issues/31051
+GO:0045136	development of animal secondary sexual characteristics	NCBITaxon:33208	Metazoa	https://github.com/geneontology/go-ontology/issues/31051
 GO:0045138	nematode male tail tip morphogenesis	NCBITaxon:6231	Nematoda	
 GO:0045152	antisigma factor binding	NCBITaxon:2	Bacteria	
 GO:0045170	spectrosome	NCBITaxon:6656	Arthropoda	


### PR DESCRIPTION
**⚠️ EVALUATION ONLY - DO NOT MERGE ⚠️**

## Original Issue
[#31051: Taxon constraint: GO:0046544 development of secondary male sexual characteristics](https://href.li/?https://github.com/geneontology/go-ontology/issues/31051)

## Original PR (human solution)
[#32037: Issue #31051: rename secondary sexual characteristic terms with 'animal' prefix](https://href.li/?https://github.com/geneontology/go-ontology/pull/32037)

## Agent Commits
- Revise secondary sexual characteristic labels

**Note**: This PR diff shows ONLY the agent's changes. The baseline is eval_base_branch.

## Agent Response - PR Comments
This revises issue #31051 to follow the last curator instruction in the thread: replace the temporary `sensu Metazoa` active labels with `animal ...` labels while retaining the animal/metazoan taxon scoping already added at the parent.

Summary of ontology changes:

- Renamed GO:0045136 to `development of animal secondary sexual characteristics`
- Renamed GO:0046543 to `development of animal secondary female sexual characteristics`
- Renamed GO:0046544 to `development of animal secondary male sexual characteristics`
- Preserved the previous `sensu Metazoa` labels as EXACT synonyms on all three terms
- Updated the `is_a` label comment on GO:0042695 `thelarche` to match the renamed female parent
- Updated the explicit `only_in_taxon.tsv` row for GO:0045136 so the text label matches the active term label

Rationale:

- The issue discussion moved past the original “never in fungi” request and converged on keeping this branch explicitly animal-scoped.
- An `only_in_taxon Metazoa` constraint is already present on GO:0045136, so the remaining cleanup was the active naming.
- The final curator instruction in the issue was to revise the temporary `sensu Metazoa` labels to the `animal ...` form for consistency with GO precedent such as `animal organ development`.

Validation and research:

- `RESEARCH.md` created locally and reference quotes validated with `linkml-reference-validator`
- `DESIGN_PATTERNS.md` created locally documenting the naming precedent and lack of a dedicated DOSDP for these terms
- `cd src/ontology && make check_all_taxon_constraints_columns` passed
- `obo-checkout.pl` / `obo-checkin.pl` workflow used for term edits
- `make travis_build` could not be completed in this environment because the local toolchain is missing `amm`
- Additional ROBOT-based validation could not be run because `robot` is not installed in this environment

Checklist:

- [x] PLAN: Issue thread reviewed through the final curator request; intent is clear
- [ ] PRE-VALIDATION: Full ontology pre-validation not possible here because `make travis_build` fails before ontology checks due missing `amm`
- [x] RESEARCH: Focused background research performed; `RESEARCH.md` created
- [x] TERM-SEARCH: Relevant GO terms consulted in `go-edit.obo`
- [x] DESIGN-PATTERNS: Naming/design precedent reviewed; `DESIGN_PATTERNS.md` created
- [x] EDITS: Used checkout/checkin workflow with local term files
- [x] RELATIONSHIPS: Existing hierarchy preserved; no new logical axioms introduced
- [x] logical definitions are appropriate, and are not over-specified, and conform to DESIGN_PATTERNS.md doc
- [x] relationships conform to other similar terms in the ontology
- [x] is_a is not over-asserted
- [x] is_a, part_of, and other relationships specified appropriately
- [x] SPECIALIZED-EDITS: `/taxon-constraint` consulted; explicit parent TC retained and label row updated
- [x] METADATA: No new terms created; existing tracker links preserved
- [ ] AUTOMATED-VALIDATION: Full `make travis_build` blocked by missing local dependency `amm`
- [x] REFERENCE-VALIDATION: Introduced research references validated against cached PubMed abstracts
- [x] CHANGES-COMMITTED
- [x] RELEVANT-FILES: committed only `src/ontology/go-edit.obo` and `src/taxon_constraints/only_in_taxon.tsv`
- [x] ACCURACY: Change aligns with the final curator direction and with active GO naming precedent
- [x] ISSUE-ALIGNMENT: The work addresses the requested follow-up revision from the issue thread
- [ ] PR is created or amended
- [x] Communicate high level summary of changes on original issue(s), and any requests for further info
- [x] Communicated on PR detailed description of changes made, and rationale. Include checklists.

---
🤖 **Generated by codex agent**
- Runtime: `codex`
- Model: `gpt-5.4`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25949055101)

## Agent Response - Issue Comments
Implemented the label revision requested in the later discussion.

Updated:

- GO:0045136 `development of animal secondary sexual characteristics`
- GO:0046543 `development of animal secondary female sexual characteristics`
- GO:0046544 `development of animal secondary male sexual characteristics`

The previous `sensu Metazoa` labels were retained as EXACT synonyms, and the existing `only_in_taxon Metazoa` on GO:0045136 was kept in place. I also updated the dependent `thelarche` parent label comment for consistency.

Changes committed locally and ready for PR #<NN>.

---
🤖 **Generated by codex agent**
- Runtime: `codex`
- Model: `gpt-5.4`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25949055101)

## Experiment Config
| Parameter | Value |
|-----------|-------|
| Model | `gpt-5.4` |
| Agent config | `ai4curation/go-ontology-agent-config@v9:.` |
| Iteration | `1` |
| URL prefix | `https://href.li/?` |
| Base branch | `eval-base-issue-31051` |

See workflow artifacts for full agent trace.