### PR TITLE
[DO NOT MERGE] eval #31965 i:1: protoporphyrinogen oxidase activity terms (opencode/openai/gpt-5.4, .)

### DIFF
--- a/src/ontology/extensions/go-lego-edit.ofn
+++ b/src/ontology/extensions/go-lego-edit.ofn
@@ -121,6 +121,6 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/ZFA_0100000> ObjectIntersectio
 SubClassOf(<http://purl.obolibrary.org/obo/ZFS_0100000> <http://purl.obolibrary.org/obo/UBERON_0000105>)
 
 
-SubClassOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/emapa#ends_at> <http://purl.obolibrary.org/obo/TS_0>) <http://purl.obolibrary.org/obo/EMAPA_0>)
-SubClassOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/emapa#starts_at> <http://purl.obolibrary.org/obo/TS_0>) <http://purl.obolibrary.org/obo/EMAPA_0>)
+SubClassOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002493> <http://purl.obolibrary.org/obo/TS_0>) <http://purl.obolibrary.org/obo/EMAPA_0>)
+SubClassOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002489> <http://purl.obolibrary.org/obo/TS_0>) <http://purl.obolibrary.org/obo/EMAPA_0>)
 )


### PR DESCRIPTION
**⚠️ EVALUATION ONLY - DO NOT MERGE ⚠️**

## Original Issue
[#31965: protoporphyrinogen oxidase activity terms](https://href.li/?https://github.com/geneontology/go-ontology/issues/31965)

## Original PR (human solution)
[#31971: Refactor protoporphyrinogen oxidase activity terms (fixes #31965)](https://href.li/?https://github.com/geneontology/go-ontology/pull/31971)

## Agent Commits
No commits from agent

**Note**: This PR diff shows ONLY the agent's changes. The baseline is eval_base_branch.

## Experiment Config
| Parameter | Value |
|-----------|-------|
| Model | `openai/gpt-5.4` |
| Agent config | `ai4curation/go-ontology-agent-config@v9:.` |
| Iteration | `1` |
| URL prefix | `https://href.li/?` |
| Base branch | `eval-base-issue-31965` |

See workflow artifacts for full agent trace.