### PR TITLE
[DO NOT MERGE] eval #31051 i:1: Taxon constraint: GO:0046544 development of secondary male sexual characteristics (opencode/openai/gpt-5.5, .)

### DIFF
--- a/src/taxon_constraints/only_in_taxon.tsv
+++ b/src/taxon_constraints/only_in_taxon.tsv
@@ -378,7 +378,7 @@ GO:0044782	cilium organization	NCBITaxon:2759	Eukaryota
 GO:0044787	bacterial-type DNA replication	NCBITaxon:2	Bacteria	
 GO:0044849	estrous cycle	NCBITaxon:32525	Theria <Mammalia>	
 GO:0044850	menstrual cycle	NCBITaxon:9443	Primates	
-GO:0045136	development of secondary sexual characteristics, sensu Metazoa	NCBITaxon:33208	Metazoa	https://github.com/geneontology/go-ontology/issues/31051
+GO:0045136	development of animal secondary sexual characteristics	NCBITaxon:33208	Metazoa	https://github.com/geneontology/go-ontology/issues/31051
 GO:0045138	nematode male tail tip morphogenesis	NCBITaxon:6231	Nematoda	
 GO:0045152	antisigma factor binding	NCBITaxon:2	Bacteria	
 GO:0045170	spectrosome	NCBITaxon:6656	Arthropoda	


### PR DESCRIPTION
**⚠️ EVALUATION ONLY - DO NOT MERGE ⚠️**

## Original Issue
[#31051: Taxon constraint: GO:0046544 development of secondary male sexual characteristics](https://href.li/?https://github.com/geneontology/go-ontology/issues/31051)

## Original PR (human solution)
[#32037: Issue #31051: rename secondary sexual characteristic terms with 'animal' prefix](https://href.li/?https://github.com/geneontology/go-ontology/pull/32037)

## Agent Commits
- Rename secondary sex characteristic terms

**Note**: This PR diff shows ONLY the agent's changes. The baseline is eval_base_branch.

## Agent Response - PR Comments
## Summary

This PR implements the latest requested resolution for issue #31051 by replacing the prior `sensu Metazoa` wording with `animal ...` labels for the secondary sexual characteristic development terms.

Changed labels:

- GO:0045136: `development of secondary sexual characteristics, sensu Metazoa` -> `development of animal secondary sexual characteristics`
- GO:0046543: `development of secondary female sexual characteristics, sensu Metazoa` -> `development of animal secondary female sexual characteristics`
- GO:0046544: `development of secondary male sexual characteristics, sensu Metazoa` -> `development of animal secondary male sexual characteristics`

The child `is_a` comments were updated to match the revised parent label. The `only_in_taxon.tsv` row for GO:0045136 was also updated so the label text matches the GO term label, while retaining the existing `NCBITaxon:33208 Metazoa` constraint and issue reference.

No definitions, synonyms, logical definitions, or taxon constraint scope were changed. The existing exact synonyms preserving the unqualified labels remain in place.

## Rationale

The issue discussion reached a curator request to prefer `animal ...` labels over `sensu Metazoa`, for consistency with existing GO terminology such as `animal organ development`. This keeps the Metazoa taxon constraint from the prior change while using a label style that is clearer and more consistent with GO precedent.

## Validation

Ran `make travis_build` from `src/ontology`.

Result: passed. All reported SPARQL checks had 0 violations.

## Checklist

- [x] PLAN: Issue context and comments reviewed; latest request was clear.
- [x] PRE-VALIDATION: Full validation was run after the edit; no separate pre-validation was needed for this label-only follow-up.
- [x] RESEARCH: No new literature research required; biological scope decision was already made in issue discussion.
- [x] TERM-SEARCH: Target stanzas for GO:0045136, GO:0046543, and GO:0046544 inspected with `obo-grep.pl`.
- [x] DESIGN-PATTERNS: Existing GO precedent for `animal ... development` labels considered; no new logical definitions added.
- [x] EDITS: Terms were edited via `obo-checkout.pl` / `obo-checkin.pl`; taxon constraint label text was updated directly in `only_in_taxon.tsv`.
- [x] RELATIONSHIPS: Existing relationships retained; child parent comments updated to match the new parent label.
- [x] SPECIALIZED-EDITS: Taxon constraint skill considered; existing Metazoa constraint retained, with only label text changed.
- [x] METADATA: Existing term tracker metadata retained; no new terms created.
- [x] AUTOMATED-VALIDATION: `make travis_build` passed.
- [x] REFERENCE-VALIDATION: No new references introduced.
- [x] CHANGES-COMMITTED: Committed local changes to `src/ontology/go-edit.obo` and `src/taxon_constraints/only_in_taxon.tsv` only.

---
🤖 **Generated by opencode agent**
- Runtime: `opencode`
- Model: `openai/gpt-5.5`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25976459884)

## Agent Response - Issue Comments
Implemented the requested follow-up from @pgaudet/@raymond91125: the three secondary sexual characteristic development terms now use `animal ...` labels rather than `sensu Metazoa` labels.

Updated labels:

- GO:0045136 `development of animal secondary sexual characteristics`
- GO:0046543 `development of animal secondary female sexual characteristics`
- GO:0046544 `development of animal secondary male sexual characteristics`

The existing exact synonyms preserving the previous unqualified labels were retained. The `only_in_taxon Metazoa` constraint on GO:0045136 was retained, and its label text in `only_in_taxon.tsv` was updated to match the new label.

Validation: `make travis_build` passed with all reported SPARQL checks at 0 violations.

Changes committed in PR #<NN>.

---
🤖 **Generated by opencode agent**
- Runtime: `opencode`
- Model: `openai/gpt-5.5`
- Agent config: `ai4curation/go-ontology-agent-config@v9:.`
- Iteration: `1`
- Run: [View workflow run](https://github.com/ai4curation/eval-ont-agent-go/actions/runs/25976459884)

## Experiment Config
| Parameter | Value |
|-----------|-------|
| Model | `openai/gpt-5.5` |
| Agent config | `ai4curation/go-ontology-agent-config@v9:.` |
| Iteration | `1` |
| URL prefix | `https://href.li/?` |
| Base branch | `eval-base-issue-31051` |

See workflow artifacts for full agent trace.